### PR TITLE
Attempt to fix a crash when fighting Bill

### DIFF
--- a/src/spec.elmuseo.c
+++ b/src/spec.elmuseo.c
@@ -1294,7 +1294,10 @@ int hakeem_waxify( CHAR* hak, CHAR* victim )
 // Faze helps Bill if he gets attacked.
 int mus_faze( CHAR *faze, CHAR *ch, int cmd, char *arg )
 {
-  if( cmd == MSG_DIE ) faze_instance = NULL; else faze_instance = faze;
+  if( cmd == MSG_DIE || cmd == MSG_DEAD || cmd == MSG_CORPSE)
+    faze_instance = NULL;
+  else
+    faze_instance = faze;
   return FALSE;
 }
 


### PR DESCRIPTION
mus_faze is intended to set faze_instance to NULL when the wax knight dies
and set it to the knight's record when the knight is alive, but the code
was treating all messages, except for MSG_DIE, as indicating that the
knight was alive. It is possible for the function to be called with
MSG_DEAD or MSG_CORPSE after the MSG_DIE, and this would cause faze_instance
to be set again, leading to a dangling pointer that could cause a crash
later on.
