### PR TITLE
QOL updates for Ronin

### DIFF
--- a/src/fight.c
+++ b/src/fight.c
@@ -3514,12 +3514,6 @@ bool perform_hit(CHAR *attacker, CHAR *defender, int type, int hit_num) {
 		
 		int circle_damage = (dam * circle_mult[GET_LEVEL(attacker)]);
 		
-		//Evasion Lowers damage of skills by 25%
-		if(IS_SET(GET_TOGGLES(attacker), TOG_EVASION) && (check_subclass(attacker, SC_BANDIT, 5))){
-			circle_damage = (circle_damage * 0.75);
-		}
-		
-		
         damage(attacker, defender, circle_damage, SKILL_CIRCLE, DAM_PHYSICAL);
 
         if ((CHAR_REAL_ROOM(defender) != NOWHERE) && special_message) {

--- a/src/spec.ctower.c
+++ b/src/spec.ctower.c
@@ -45,7 +45,6 @@
 #define TOOTH          17395
 #define MITHRIL_BAR    17394
 #define ANVIL          17392
-#define KEY_DECAY      17316
 #define VAULT_ROOM     17338
 #define KIRI_VAULT     17339
 #define GOLEM          17300
@@ -289,36 +288,6 @@ int elf_maiden(CHAR *mob, CHAR *vict, int cmd, char *arg) {
    return FALSE;
 }
 
-int key_decay(OBJ *obj, CHAR *ch, int cmd, char *argument) {
-  bool carry=FALSE,wear=FALSE;
-  CHAR *vict;
-  int dam;
-
-  if(cmd!=MSG_TICK) return FALSE;
-
-  if (obj->equipped_by) {
-    wear=TRUE;
-    vict=obj->equipped_by;
-  }
-  else if (obj->carried_by) {
-    carry=TRUE;
-    vict=obj->carried_by;
-  }
-  else return FALSE;
-
-  if(IS_NPC(vict) && V_MOB(vict)==17322) return FALSE;
-
-  if(obj_proto_table[obj->item_number].number > 1) {
-    act("The $o explodes with fiery force!",FALSE,vict,obj,0,TO_CHAR);
-    act("$n's $o explodes with fiery force!",FALSE,vict,obj,0,TO_ROOM);
-    if(wear) extract_obj(unequip_char (vict, HOLD));
-    if(carry) extract_obj (obj);
-    dam=MIN(50,GET_HIT(vict)-1);
-    damage(vict,vict,dam,TYPE_UNDEFINED,DAM_NO_BLOCK);
-  }
-  return FALSE;
-}
-
 int volcano_rooms(int room, CHAR *ch, int cmd, char *arg)
 {
   OBJ *k;
@@ -558,7 +527,6 @@ void assign_ctower(void) {
   assign_mob(KIRI_TORIN,   kiri_torin);
   assign_room(MIRROR_ROOM, mirror);
   assign_obj(FANG,         fang);
-  //assign_obj(KEY_DECAY,    key_decay);
   assign_obj(HAMMER,       hammer);
   assign_obj(PAN,          pan);
   assign_obj(DRAGON_TOOTH, dragon_tooth);

--- a/src/spec.ctower.c
+++ b/src/spec.ctower.c
@@ -558,7 +558,7 @@ void assign_ctower(void) {
   assign_mob(KIRI_TORIN,   kiri_torin);
   assign_room(MIRROR_ROOM, mirror);
   assign_obj(FANG,         fang);
-  assign_obj(KEY_DECAY,    key_decay);
+  //assign_obj(KEY_DECAY,    key_decay);
   assign_obj(HAMMER,       hammer);
   assign_obj(PAN,          pan);
   assign_obj(DRAGON_TOOTH, dragon_tooth);

--- a/src/spec.elmuseo.c
+++ b/src/spec.elmuseo.c
@@ -1301,16 +1301,16 @@ int mus_faze( CHAR *faze, CHAR *ch, int cmd, char *arg )
 // Bill, the Knight Janitor, periodically drops off new pots of wax for Hakeem until he has at least 5.
 int mus_bill( CHAR *bill, CHAR *ch, int cmd, char *arg )
 {
-  CHAR *faze_validation;
 	
+  CHAR *faze_validation;
+  
   if( !bill || cmd != MSG_MOBACT )
     return FALSE;
 
   // If fighting, Faze will try to come assist.
   if( GET_POS( bill ) == POSITION_FIGHTING && faze_instance && GET_POS( faze_instance ) == POSITION_STANDING )
   {
-	
-	//Validate that Faze still exists.
+   //Validate that Faze still exists.
 	faze_validation = get_ch_world(MUS_FAZE);
 	
 	if(faze_validation){	  
@@ -3573,6 +3573,19 @@ int ench_forest_friend(ENCH *ench, CHAR *ench_ch, CHAR *ch, int cmd, char*arg ) 
   GET_HIT(ench_ch) = GET_MAX_HIT(ench_ch);
   //So, this kind of sucks, can't make them stop fighting, but we can make them miss maybe
   ench_ch->points.armor = -500;
+  //drop items in inventory
+  act("$n abandons all $s worldly possessions as it flees to freedom.", 1, ench_ch, 0, 0, TO_NOTVICT);
+  for (OBJ *temp_obj = GET_CARRYING(ench_ch), *next_obj; temp_obj; temp_obj = next_obj) {
+    next_obj = OBJ_NEXT_CONTENT(temp_obj);
+
+    obj_from_char(temp_obj);
+    obj_to_room(temp_obj, CHAR_REAL_ROOM(ench_ch));
+  }
+  //drop equipped items
+  for (int eq_slot = 0; eq_slot < MAX_WEAR; eq_slot++)
+    if (EQ(ench_ch,eq_slot))
+      obj_to_room(unequip_char(ench_ch,eq_slot), CHAR_REAL_ROOM(ench_ch));
+
   char_from_room(ench_ch);
   char_to_room(ench_ch,real_room(MUS_SANCTUARY));
 
@@ -3606,7 +3619,7 @@ int mus_black_leggings(OBJ *obj, CHAR *ch, int cmd, char *arg) {
   CHAR *vict = owner->specials.fighting;
   if(CHAOSMODE) return FALSE;
   /* Find the person who is getting killed ... */
-  if(!IS_MOB(vict)) return FALSE;
+  if(!IS_MOB(vict) || GET_QUEST_OWNER(vict)) return FALSE;
   if(!(GET_CLASS(vict) == CLASS_AVIAN ||  GET_CLASS(vict) == CLASS_FISH || GET_CLASS(vict) == CLASS_ANIMAL || GET_CLASS(vict) == CLASS_SIMIAN || GET_CLASS(vict) == CLASS_CANINE || GET_CLASS(vict) == CLASS_FELINE || GET_CLASS(vict) == CLASS_RODENT))
     return FALSE;
   if(GET_LEVEL(vict) >= LEVEL_IMM-1) return FALSE;
@@ -3660,7 +3673,7 @@ int mus_antlers(OBJ *obj, CHAR *ch, int cmd, char *arg) {
     sprintf(buf, "As $n begins to %s, $s antlers tumble to the ground.", cmd == CMD_CLIMB ? "climb" : (cmd == CMD_CRAWL ? "crawl" : "jump"));
     act(buf, 1, ch, 0, 0, TO_ROOM);
     mus_remeq(ch, WEAR_SHIELD);
-    return TRUE;
+    return FALSE;
   }
 
   CHAR *wearer = obj->equipped_by;

--- a/src/spec.elmuseo.c
+++ b/src/spec.elmuseo.c
@@ -1301,15 +1301,23 @@ int mus_faze( CHAR *faze, CHAR *ch, int cmd, char *arg )
 // Bill, the Knight Janitor, periodically drops off new pots of wax for Hakeem until he has at least 5.
 int mus_bill( CHAR *bill, CHAR *ch, int cmd, char *arg )
 {
+  CHAR *faze_validation;
+	
   if( !bill || cmd != MSG_MOBACT )
     return FALSE;
 
   // If fighting, Faze will try to come assist.
   if( GET_POS( bill ) == POSITION_FIGHTING && faze_instance && GET_POS( faze_instance ) == POSITION_STANDING )
   {
-    mob_do( faze_instance, "op door" );
-    mob_do( faze_instance, "north" );
-    mob_do( faze_instance, "assist bill" );
+	
+	//Validate that Faze still exists.
+	faze_validation = get_ch_world(MUS_FAZE);
+	
+	if(faze_validation){	  
+		mob_do( faze_instance, "op door" );
+		mob_do( faze_instance, "north" );
+		mob_do( faze_instance, "assist bill" );
+	}
   }
 
   // Sleeping or fighting => no wax for you!
@@ -3565,19 +3573,6 @@ int ench_forest_friend(ENCH *ench, CHAR *ench_ch, CHAR *ch, int cmd, char*arg ) 
   GET_HIT(ench_ch) = GET_MAX_HIT(ench_ch);
   //So, this kind of sucks, can't make them stop fighting, but we can make them miss maybe
   ench_ch->points.armor = -500;
-  //drop items in inventory
-  act("$n abandons all $s worldly possessions as it flees to freedom.", 1, ench_ch, 0, 0, TO_NOTVICT);
-  for (OBJ *temp_obj = GET_CARRYING(ench_ch), *next_obj; temp_obj; temp_obj = next_obj) {
-    next_obj = OBJ_NEXT_CONTENT(temp_obj);
-
-    obj_from_char(temp_obj);
-    obj_to_room(temp_obj, CHAR_REAL_ROOM(ench_ch));
-  }
-  //drop equipped items
-  for (int eq_slot = 0; eq_slot < MAX_WEAR; eq_slot++)
-    if (EQ(ench_ch,eq_slot))
-      obj_to_room(unequip_char(ench_ch,eq_slot), CHAR_REAL_ROOM(ench_ch));
-
   char_from_room(ench_ch);
   char_to_room(ench_ch,real_room(MUS_SANCTUARY));
 
@@ -3611,7 +3606,7 @@ int mus_black_leggings(OBJ *obj, CHAR *ch, int cmd, char *arg) {
   CHAR *vict = owner->specials.fighting;
   if(CHAOSMODE) return FALSE;
   /* Find the person who is getting killed ... */
-  if(!IS_MOB(vict) || GET_QUEST_OWNER(vict)) return FALSE;
+  if(!IS_MOB(vict)) return FALSE;
   if(!(GET_CLASS(vict) == CLASS_AVIAN ||  GET_CLASS(vict) == CLASS_FISH || GET_CLASS(vict) == CLASS_ANIMAL || GET_CLASS(vict) == CLASS_SIMIAN || GET_CLASS(vict) == CLASS_CANINE || GET_CLASS(vict) == CLASS_FELINE || GET_CLASS(vict) == CLASS_RODENT))
     return FALSE;
   if(GET_LEVEL(vict) >= LEVEL_IMM-1) return FALSE;
@@ -3665,7 +3660,7 @@ int mus_antlers(OBJ *obj, CHAR *ch, int cmd, char *arg) {
     sprintf(buf, "As $n begins to %s, $s antlers tumble to the ground.", cmd == CMD_CLIMB ? "climb" : (cmd == CMD_CRAWL ? "crawl" : "jump"));
     act(buf, 1, ch, 0, 0, TO_ROOM);
     mus_remeq(ch, WEAR_SHIELD);
-    return FALSE;
+    return TRUE;
   }
 
   CHAR *wearer = obj->equipped_by;


### PR DESCRIPTION
The Kiri-Torin key decay spec is causing issues, because the key explodes if others do the AQ.   REmoving the spec to ensure no loss of gear/