### PR TITLE
August QoL Patch

### DIFF
--- a/lib/world/DreadfulSwamprevampbyLeha.mob
+++ b/lib/world/DreadfulSwamprevampbyLeha.mob
@@ -420,7 +420,7 @@ never trust a two-head monster in dark robes.
 79 0 0d0+0 0
 0 1 0 0
 K
-0 0 0 0 0 0 0
+0 12000 0 0 0 0 0
 #12024
 salamander sal~
 a Salamander~

--- a/lib/world/DreadfulSwamprevampbyLeha.obj
+++ b/lib/world/DreadfulSwamprevampbyLeha.obj
@@ -1,3 +1,20 @@
+#12000
+vial stone liquid potion~
+a vial of liquid stone~
+A gritty gray potion within a sturdy vial lies here.~
+~
+10 0 1
+50 143 -1 -1
+5 50 175
+100
+X
+~
+0 0 0
+M
+~
+~
+~
+~
 #12001
 plate golden breast breastplate~
 golden breastplate~

--- a/lib/world/DreadfulSwamprevampbyLeha.zon
+++ b/lib/world/DreadfulSwamprevampbyLeha.zon
@@ -1,7 +1,7 @@
 #120
 Dreadful Swamp revamp by Leha~
 12099 25 2
-X 0 Unknown 16Jun2021 Unknown
+X 0 Unknown  1Aug2026 Unknown
 Y 100 100 100 100 100 100 100 100
 M 0 12022 1 12023
 M 0 12015 10 12113

--- a/lib/world/OgreVillagebyDionysus.mob
+++ b/lib/world/OgreVillagebyDionysus.mob
@@ -629,7 +629,7 @@ return to his home plane, and so Eowadriendir was forced to confine him
 in this pentagon, where he has remained for hundreds of years.
 
 ~
-4138 805570696 -1000 Y
+4138 805568648 -1000 Y
 50 -30 -30 100d300+6000 10d60+60
 0 5000000
 8 8 1

--- a/lib/world/OgreVillagebyDionysus.obj
+++ b/lib/world/OgreVillagebyDionysus.obj
@@ -472,20 +472,7 @@ A decaying manuscript sits here.~
 10 10 10
 2
 E
-manuscript ancient~
-In the Month of the Battle, Year 143 of the Second Great Age
-of Dark, the Storm Giant King Calaphas visited the realm of
-his giant-kin brethren, the Ogres.
-
-The visit was a matter of state, and he was greeted with all
-pomp and circumstance by the Ogre King, Urshkank.  Though
-relations between the two kingdoms had been strained for
-many years, Urshkank had high hopes for the meeting.  He
-believed that Calaphas came to extend his hand in friendship,
-that the two kingdoms could work together to prosper and
-battle against the rising alliance of Elves which threatened
-their mutual survival.
-
+page2~
 Instead what occurred was a betrayal of the worst sort.  As
 soon as the meeting had begun and the two were left alone,
 Calaphas turned on Urshkank, pinning him beneath his
@@ -494,12 +481,13 @@ storm-born gauntlets and choking the life from him.
 In the chaos and confusion that followed, Calaphas set fire
 to the keep, a signal to those who lay in wait.  Within minutes
 an army of Storm Giants, supported by their sworn enemies,
-~
-E
-manuscript ancient~
-This ancient manuscript is scrawled in a sloppy hand, as
-though by a scarcely literate person.  There are only
-two pages, and they are both quite short.
+the Elves of the Mountains, swept in and massacred nearly
+the entire Ogre population.
+
+That day, the day of the Great Gods, was the final end of
+the mighty kingdom of the Ogres, but it too signaled the
+decline of the other giant-kin, and of the mighty Giants
+themselves.
 ~
 E
 page1~
@@ -517,7 +505,26 @@ battle against the rising alliance of Elves which threatened
 their mutual survival.
 ~
 E
-page2~
+manuscript ancient~
+This ancient manuscript is scrawled in a sloppy hand, as
+though by a scarcely literate person.  There are only
+two pages, and they are both quite short.
+~
+E
+manuscript ancient~
+In the Month of the Battle, Year 143 of the Second Great Age
+of Dark, the Storm Giant King Calaphas visited the realm of
+his giant-kin brethren, the Ogres.
+
+The visit was a matter of state, and he was greeted with all
+pomp and circumstance by the Ogre King, Urshkank.  Though
+relations between the two kingdoms had been strained for
+many years, Urshkank had high hopes for the meeting.  He
+believed that Calaphas came to extend his hand in friendship,
+that the two kingdoms could work together to prosper and
+battle against the rising alliance of Elves which threatened
+their mutual survival.
+
 Instead what occurred was a betrayal of the worst sort.  As
 soon as the meeting had begun and the two were left alone,
 Calaphas turned on Urshkank, pinning him beneath his
@@ -526,13 +533,6 @@ storm-born gauntlets and choking the life from him.
 In the chaos and confusion that followed, Calaphas set fire
 to the keep, a signal to those who lay in wait.  Within minutes
 an army of Storm Giants, supported by their sworn enemies,
-the Elves of the Mountains, swept in and massacred nearly
-the entire Ogre population.
-
-That day, the day of the Great Gods, was the final end of
-the mighty kingdom of the Ogres, but it too signaled the
-decline of the other giant-kin, and of the mighty Giants
-themselves.
 ~
 X
 ~

--- a/lib/world/OgreVillagebyDionysus.zon
+++ b/lib/world/OgreVillagebyDionysus.zon
@@ -1,7 +1,7 @@
 #213
 Ogre Village, by Dionysus~
 21352 49 2
-X 0 28Mar2002 20Jul2020 DionysusUrsum
+X 0 28Mar2002  2Aug2026 DionysusUrsum
 Y 100 100 100 100 100 100 100 100
 M 0 21335 1 21306
 M 0 21304 1 21321

--- a/src/act.obj2.c
+++ b/src/act.obj2.c
@@ -20,6 +20,7 @@
 #include "utility.h"
 #include "act.h"
 #include "limits.h"
+#include "aquest.h"
 #include "cmd.h"
 #include "subclass.h"
 
@@ -270,15 +271,7 @@ void do_tap(struct char_data *ch, char *argument, int cmd)
       death_list(vict);
       strip_char(vict);
 
-      if(vict->quest_status==QUEST_RUNNING || vict->quest_status==QUEST_COMPLETED)
-        vict->ver3.time_to_quest=30;
-      vict->questgiver=0;
-      if(vict->questobj) vict->questobj->owned_by=0;
-      vict->questobj=0;
-      if(vict->questmob) vict->questmob->questowner=0;
-      vict->questmob=0;
-      vict->quest_status=QUEST_NONE;
-      vict->quest_level=0;
+      aq_fail_quest(vict, QUEST_NONE);
 
       save_char(vict, NOWHERE);
       extract_char(vict);

--- a/src/act.offensive.c
+++ b/src/act.offensive.c
@@ -1685,7 +1685,7 @@ void do_kick(CHAR *ch, char *arg, int cmd) {
 
   CHAR *victim = get_char_room_vis(ch, name);
 
-  if (!victim && IS_ALIVE(GET_OPPONENT(ch)) && SAME_ROOM(ch, victim)) {
+  if (!victim && IS_ALIVE(GET_OPPONENT(ch)) && SAME_ROOM(ch, GET_OPPONENT(ch))) {
     victim = GET_OPPONENT(ch);
   }
 

--- a/src/act.other.c
+++ b/src/act.other.c
@@ -173,7 +173,6 @@ void do_quit(struct char_data *ch, char *argument, int cmd)
   int i;
   int wearing = FALSE;
   char buf[MAX_STRING_LENGTH];
-  OBJ *tmp_obj;
 
   void die(struct char_data *ch);
   void strip_char(CHAR *ch);
@@ -219,39 +218,33 @@ void do_quit(struct char_data *ch, char *argument, int cmd)
     stop_riding(ch,ch->specials.riding);
   }
 
-  if (IS_IMMORTAL(ch)) {
-    GET_QUEST_TIMER(ch) = 0;
-  }
-  else {
-    ch->ver3.time_to_quest = MAX(ch->ver3.time_to_quest - 40, 5);
-  }
-
-  if(ch->quest_status==QUEST_FAILED) {
-    printf_to_char(ch,"You have failed your quest, you can start another in %d ticks.\n\r",ch->ver3.time_to_quest);
-  }
-  if(ch->quest_status==QUEST_RUNNING || ch->quest_status==QUEST_COMPLETED) {
-    printf_to_char(ch,"Your quest has been automatically ended, you can start another in %d ticks.\n\r",ch->ver3.time_to_quest);
-  }
-  ch->questgiver=0;
-  if(ch->questobj)
   {
-    if(V_OBJ(ch->questobj) == 35)
-    {
-      for(tmp_obj = object_list; tmp_obj; tmp_obj = tmp_obj->next)
-      {
-        if(V_OBJ(tmp_obj) != 35) continue; //not a questcard? skip
-        if(OBJ_SPEC(tmp_obj) != ch->ver3.id) continue; //not the char's questcard? skip
-        extract_obj(tmp_obj);
+    int prev_quest_status = ch->quest_status;
+
+    if (prev_quest_status == QUEST_RUNNING || prev_quest_status == QUEST_COMPLETED) {
+      /* actually interrupting a quest -- apply the standard cooldown */
+      aq_fail_quest(ch, QUEST_NONE);
+      if (IS_IMMORTAL(ch))
+        GET_QUEST_TIMER(ch) = 0; /* imms aren't subject to the cooldown */
+
+      printf_to_char(ch,"Your quest has been automatically ended, you can start another in %d ticks.\n\r",ch->ver3.time_to_quest);
+    }
+    else {
+      /* no active quest to fail -- just clear stale pointers, leave any
+         existing cooldown (from an earlier failure) ticking on its own */
+      ch->questgiver = 0;
+      if (ch->questobj) ch->questobj->owned_by = 0;
+      ch->questobj = 0;
+      if (ch->questmob) ch->questmob->questowner = 0;
+      ch->questmob = 0;
+      ch->quest_status = QUEST_NONE;
+      ch->quest_level = 0;
+
+      if (prev_quest_status == QUEST_FAILED) {
+        printf_to_char(ch,"You have failed your quest, you can start another in %d ticks.\n\r",ch->ver3.time_to_quest);
       }
     }
-    else
-      ch->questobj->owned_by=0;
   }
-  ch->questobj=0;
-  if(ch->questmob) ch->questmob->questowner=0;
-  ch->questmob=0;
-  ch->quest_status=QUEST_NONE;
-  ch->quest_level=0;
 
   if( (GET_LEVEL(ch) < LEVEL_IMM) && IS_SET(ch->specials.pflag, PLR_QUEST)) REMOVE_BIT(ch->specials.pflag, PLR_QUEST);
   /* Ranger - June 96 */

--- a/src/aquest.c
+++ b/src/aquest.c
@@ -53,24 +53,25 @@ int check_guildmaster(CHAR *ch, CHAR *mob) {
 #define AQCARDS_SPREAD 25
 
 /*
- * AQ_FAIL_DECAY_OFFSET / AQ_MIN_COOLDOWN define the single source of
- * truth for how long a player must wait before starting a new AQ
- * after their current one is interrupted for any reason (death, quit,
- * rent, natural expiry, quest mob/giver killed by someone else,
- * hotboot/crash recovery, etc).
- *
- * The cooldown scales with how much of the quest you'd already used:
- * fail almost immediately and you wait close to the max; fail near
- * the very end (or the timer expires naturally) and you only wait
- * the floor. Concretely: cooldown = MAX(ticks_remaining - 40, 5).
- * Since a quest starts with 60 ticks, that means at most 20 ticks
- * of cooldown (failing right away) down to a floor of 5 (failing
- * once you've already burned through most/all of the 60).
- *
- * Do NOT hand-roll this math at individual call sites -- route every
- * quest interruption through aq_fail_quest() below so the displayed
- * message and the stored timer can never disagree, and so the curve
- * can be re-tuned in exactly one place.
+ AQ_FAIL_DECAY_OFFSET / AQ_MIN_COOLDOWN define the decay curve used
+ for AQ interruptions that are within the player's control: quit,
+ rent, auto-rent, and natural expiry. (Interruptions that aren't
+ the player's fault -- death, quest mob/giver killed by someone else,
+ hotboot/crash recovery -- use the flat AQ_INNOCENT_COOLDOWN via
+ aq_fail_quest_flat() instead; see below.)
+
+ The cooldown scales with how much of the quest you'd already used:
+ fail almost immediately and you wait close to the max; fail near
+ the very end (or the timer expires naturally) and you only wait
+ the floor. Concretely: cooldown = MAX(ticks_remaining - 40, 5).
+ Since a quest starts with 60 ticks, that means at most 20 ticks
+ of cooldown (failing right away) down to a floor of 5 (failing
+ once you've already burned through most/all of the 60).
+
+ Do NOT hand-roll this math at individual call sites -- route every
+ quest interruption through aq_fail_quest() below so the displayed
+ message and the stored timer can never disagree, and so the curve
+ can be re-tuned in exactly one place.
  */
 #define AQ_FAIL_DECAY_OFFSET 40
 #define AQ_MIN_COOLDOWN       5
@@ -78,16 +79,20 @@ int check_guildmaster(CHAR *ch, CHAR *mob) {
 void aqcard_cleanup(int id); /* defined below; forward-declared for aq_fail_quest() */
 
 /*
- * Ends ch's currently running/completed AQ (if any) and applies the
- * standard failure cooldown, scaled by how much of the quest's time
- * budget was already used (see AQ_FAIL_DECAY_OFFSET above).
- * `new_status` is normally QUEST_FAILED, but QUEST_NONE is also valid
- * for paths that don't want to track a distinct "failed" state (e.g.
- * voluntary quit).
- *
- * Safe to call even if ch has no active quest -- it will just reset
- * the (already-empty) quest fields; ticks_remaining will be whatever
- * time_to_quest already held (e.g. 0), so the floor cooldown applies.
+ Ends ch's currently running/completed AQ (if any) and applies the
+ decay-curve failure cooldown, scaled by how much of the quest's time
+ budget was already used (see AQ_FAIL_DECAY_OFFSET above).
+ Use this for interruptions within the player's control (quit, rent,
+ natural expiry); use aq_fail_quest_flat() instead for interruptions
+ that aren't the player's fault.
+
+ `new_status` is normally QUEST_FAILED, but QUEST_NONE is also valid
+ for paths that don't want to track a distinct "failed" state (e.g.
+ voluntary quit).
+
+ Safe to call even if ch has no active quest -- it will just reset
+ the (already-empty) quest fields; ticks_remaining will be whatever
+ time_to_quest already held (e.g. 0), so the floor cooldown applies.
  */
 void aq_fail_quest(CHAR *ch, int new_status) {
   const int aqcard_vnum = 35;

--- a/src/aquest.c
+++ b/src/aquest.c
@@ -1751,7 +1751,7 @@ const int aq_obj_master_list[][2] = {
   {4487, 15}, // Gown of Good Judgement 9
   {4488, 15}, // Axe of Justice 10
   {4489, 15}, // Ornament of Righteousness  6 
-  //{5807, 15}, // Silk Suit 20
+  {5807, 15}, // Silk Suit 20
   {11700, 15}, // Soul Stealer 8
   {11712, 15}, // Armor of Dark Angels 8
   {19400, 15}, // An Extraordinarily Large Grolem Beak 10  

--- a/src/aquest.c
+++ b/src/aquest.c
@@ -52,6 +52,97 @@ int check_guildmaster(CHAR *ch, CHAR *mob) {
 
 #define AQCARDS_SPREAD 25
 
+/*
+ * AQ_FAIL_DECAY_OFFSET / AQ_MIN_COOLDOWN define the single source of
+ * truth for how long a player must wait before starting a new AQ
+ * after their current one is interrupted for any reason (death, quit,
+ * rent, natural expiry, quest mob/giver killed by someone else,
+ * hotboot/crash recovery, etc).
+ *
+ * The cooldown scales with how much of the quest you'd already used:
+ * fail almost immediately and you wait close to the max; fail near
+ * the very end (or the timer expires naturally) and you only wait
+ * the floor. Concretely: cooldown = MAX(ticks_remaining - 40, 5).
+ * Since a quest starts with 60 ticks, that means at most 20 ticks
+ * of cooldown (failing right away) down to a floor of 5 (failing
+ * once you've already burned through most/all of the 60).
+ *
+ * Do NOT hand-roll this math at individual call sites -- route every
+ * quest interruption through aq_fail_quest() below so the displayed
+ * message and the stored timer can never disagree, and so the curve
+ * can be re-tuned in exactly one place.
+ */
+#define AQ_FAIL_DECAY_OFFSET 40
+#define AQ_MIN_COOLDOWN       5
+
+void aqcard_cleanup(int id); /* defined below; forward-declared for aq_fail_quest() */
+
+/*
+ * Ends ch's currently running/completed AQ (if any) and applies the
+ * standard failure cooldown, scaled by how much of the quest's time
+ * budget was already used (see AQ_FAIL_DECAY_OFFSET above).
+ * `new_status` is normally QUEST_FAILED, but QUEST_NONE is also valid
+ * for paths that don't want to track a distinct "failed" state (e.g.
+ * voluntary quit).
+ *
+ * Safe to call even if ch has no active quest -- it will just reset
+ * the (already-empty) quest fields; ticks_remaining will be whatever
+ * time_to_quest already held (e.g. 0), so the floor cooldown applies.
+ */
+void aq_fail_quest(CHAR *ch, int new_status) {
+  const int aqcard_vnum = 35;
+  int ticks_remaining;
+
+  if (!ch || IS_NPC(ch)) return;
+
+  ticks_remaining = GET_QUEST_TIMER(ch); /* capture before we overwrite it below */
+
+  if (GET_QUEST_MOB(ch)) GET_QUEST_OWNER(GET_QUEST_MOB(ch)) = NULL;
+
+  if (GET_QUEST_OBJ(ch)) {
+    if (V_OBJ(GET_QUEST_OBJ(ch)) == aqcard_vnum)
+      aqcard_cleanup(GET_ID(ch));
+    else
+      OBJ_OWNED_BY(GET_QUEST_OBJ(ch)) = NULL;
+  }
+
+  GET_QUEST_GIVER(ch) = NULL;
+  GET_QUEST_MOB(ch)   = NULL;
+  GET_QUEST_OBJ(ch)   = NULL;
+  GET_QUEST_LEVEL(ch) = 0;
+  GET_QUEST_STATUS(ch) = new_status;
+  GET_QUEST_TIMER(ch)  = MAX(ticks_remaining - AQ_FAIL_DECAY_OFFSET, AQ_MIN_COOLDOWN);
+}
+
+/*
+ * Same cleanup as aq_fail_quest(), but for cases that aren't the
+ * player's fault (they died, or their quest mob/guildmaster was
+ * killed by someone else) -- applies a short flat mercy cooldown
+ * instead of the normal decay curve. See AQ_INNOCENT_COOLDOWN in
+ * aquest.h for the value used at most call sites.
+ */
+void aq_fail_quest_flat(CHAR *ch, int new_status, int cooldown) {
+  const int aqcard_vnum = 35;
+
+  if (!ch || IS_NPC(ch)) return;
+
+  if (GET_QUEST_MOB(ch)) GET_QUEST_OWNER(GET_QUEST_MOB(ch)) = NULL;
+
+  if (GET_QUEST_OBJ(ch)) {
+    if (V_OBJ(GET_QUEST_OBJ(ch)) == aqcard_vnum)
+      aqcard_cleanup(GET_ID(ch));
+    else
+      OBJ_OWNED_BY(GET_QUEST_OBJ(ch)) = NULL;
+  }
+
+  GET_QUEST_GIVER(ch) = NULL;
+  GET_QUEST_MOB(ch)   = NULL;
+  GET_QUEST_OBJ(ch)   = NULL;
+  GET_QUEST_LEVEL(ch) = 0;
+  GET_QUEST_STATUS(ch) = new_status;
+  GET_QUEST_TIMER(ch)  = cooldown;
+}
+
 const int aq_card[] = {//should this be in constants.c?
  2, /* 1 aq point */
  4, /* 2 aq point */
@@ -166,24 +257,10 @@ This command is used to handle automatic questing from guildmasters.\n\r\n\r\
         printf_to_char(ch, "You have failed your quest, you can start another in %d ticks.\n\r", ch->ver3.time_to_quest);
       }
       else {
-        ch->questgiver = 0;
-        if (ch->questobj) {
-          if (V_OBJ(ch->questobj) == 35)
-            aqcard_cleanup(ch->ver3.id);
-          else
-            ch->questobj->owned_by = 0;
-        }
-        ch->questobj = 0;
-        if (ch->questmob)
-          ch->questmob->questowner = 0;
-        ch->questmob = 0;
-        ch->quest_status = QUEST_NONE;
-        ch->quest_level = 0;
+        aq_fail_quest(ch, QUEST_NONE);
 #ifndef TESTSITE
-        if (GET_LEVEL(ch) < LEVEL_IMM)
-          ch->ver3.time_to_quest = MAX(ch->ver3.time_to_quest - 40, 5);
-        else
-          ch->ver3.time_to_quest = 0;
+        if (GET_LEVEL(ch) >= LEVEL_IMM)
+          ch->ver3.time_to_quest = 0; /* imms aren't subject to the cooldown */
 #else
         ch->ver3.time_to_quest = 0;
 #endif

--- a/src/aquest.h
+++ b/src/aquest.h
@@ -11,4 +11,11 @@
 
 bool is_order_item(int vnum);
 
+/* Flat cooldown for quest interruptions that aren't the player's fault
+   (death, quest mob/guildmaster killed by someone else). */
+#define AQ_INNOCENT_COOLDOWN 2
+
+void aq_fail_quest(CHAR *ch, int new_status);
+void aq_fail_quest_flat(CHAR *ch, int new_status, int cooldown);
+
 #endif /* _AQUEST_H_ */

--- a/src/comm.c
+++ b/src/comm.c
@@ -50,6 +50,7 @@
 #include "aff_ench.h"
 #include "char_spec.h"
 #include "mcheck.h"
+#include "aquest.h"
 
 #define DFLT_PORT 5000        /* default port */
 #define MAX_NAME_LENGTH 15
@@ -1304,6 +1305,19 @@ void copyover_recover(void) {
         default:
           log_s("Version number corrupted? (copyover)");
           fOld=FALSE;
+      }
+
+      /* quest_status (and questgiver/questmob/questobj) are NOT part of
+         the char_file_u_5 save format, so they don't survive a hotboot
+         restore -- they silently reset to QUEST_NONE/NULL on the fresh
+         struct. time_to_quest DOES survive (it's inside ver3, which is
+         bulk-copied above). So we can't check status to see if a quest
+         was interrupted; instead, treat any nonzero leftover timer as
+         an interrupted quest. A hotboot/crash isn't the player's fault,
+         so use the flat mercy cooldown rather than the decay formula.
+         If the timer's already 0, there's nothing to penalize -- leave it. */
+      if (fOld && GET_QUEST_TIMER(d->character) > 0) {
+        aq_fail_quest_flat(d->character, QUEST_FAILED, AQ_INNOCENT_COOLDOWN);
       }
     }
 

--- a/src/fight.c
+++ b/src/fight.c
@@ -18,6 +18,7 @@
 #include "utils.h"
 #include "comm.h"
 #include "act.h"
+#include "aquest.h"
 #include "handler.h"
 #include "interpreter.h"
 #include "db.h"
@@ -602,29 +603,16 @@ void death_list(CHAR *ch)
 
 void raw_kill_ex(CHAR *victim, bool statue) {
   if (!IS_NPC(victim)) {
-    if (GET_QUEST_MOB(victim)) GET_QUEST_OWNER(GET_QUEST_MOB(victim)) = 0;
-    if (GET_QUEST_OBJ(victim)) OBJ_OWNED_BY(GET_QUEST_OBJ(victim)) = 0;
-
-    GET_QUEST_STATUS(victim) = QUEST_NONE;
-    GET_QUEST_GIVER(victim) = 0;
-    GET_QUEST_MOB(victim) = 0;
-    GET_QUEST_OBJ(victim) = 0;
-    GET_QUEST_LEVEL(victim) = 0;
-    GET_QUEST_TIMER(victim) = MAX(GET_QUEST_TIMER(victim) - 40, 5);
+    aq_fail_quest_flat(victim, QUEST_NONE, AQ_INNOCENT_COOLDOWN);
   }
   else if (IS_NPC(victim) && GET_QUEST_OWNER(victim)) {
-    GET_QUEST_STATUS(GET_QUEST_OWNER(victim)) = QUEST_FAILED;
-    GET_QUEST_GIVER(GET_QUEST_OWNER(victim)) = 0;
-    GET_QUEST_MOB(GET_QUEST_OWNER(victim)) = 0;
-    GET_QUEST_OBJ(GET_QUEST_OWNER(victim)) = 0;
-    GET_QUEST_LEVEL(GET_QUEST_OWNER(victim)) = 0;
-    GET_QUEST_TIMER(GET_QUEST_OWNER(victim)) = 2;
+    CHAR *owner = GET_QUEST_OWNER(victim);
 
-    printf_to_char(GET_QUEST_OWNER(victim),
+    aq_fail_quest_flat(owner, QUEST_FAILED, AQ_INNOCENT_COOLDOWN);
+
+    printf_to_char(owner,
       "Your quest target has been killed, you have failed your quest! You can start another in %d ticks.\n\r",
-      GET_QUEST_TIMER(GET_QUEST_OWNER(victim)));
-
-    GET_QUEST_OWNER(victim) = 0;
+      GET_QUEST_TIMER(owner));
   }
 
   stop_fighting(victim);
@@ -998,16 +986,7 @@ void divide_experience(CHAR *ch, CHAR *victim, int none)
           if (!IS_NPC(tmp_char) &&
             tmp_char->questgiver == victim)
           {
-            if (tmp_char->questmob)
-            {
-              tmp_char->questmob->questowner = NULL;
-            }
-
-            tmp_char->questmob = NULL;
-            tmp_char->questgiver = NULL;
-            tmp_char->quest_status = QUEST_FAILED;
-            tmp_char->quest_level = 0;
-            tmp_char->ver3.time_to_quest = 2;
+            aq_fail_quest_flat(tmp_char, QUEST_FAILED, AQ_INNOCENT_COOLDOWN);
 
             printf_to_char(tmp_char, "Someone has killed your guildmaster; you have failed your quest! You can start another in %d tick(s).\n\r",
               tmp_char->ver3.time_to_quest);

--- a/src/limits.c
+++ b/src/limits.c
@@ -26,6 +26,7 @@
 #include "subclass.h"
 #include "enchant.h"
 #include "aff_ench.h"
+#include "aquest.h"
 
 /* Defines */
 
@@ -1283,27 +1284,7 @@ void point_update(void) {
         GET_QUEST_TIMER(ch) = 0;
 
         if (GET_QUEST_STATUS(ch) == QUEST_RUNNING) {
-          if (GET_QUEST_MOB(ch)) {
-            GET_QUEST_OWNER(GET_QUEST_MOB(ch)) = NULL;
-          }
-
-          if (GET_QUEST_OBJ(ch)) {
-            const int aqcard_vnum = 35;
-
-            if (V_OBJ(GET_QUEST_OBJ(ch)) == aqcard_vnum) {
-              aqcard_cleanup(GET_ID(ch));
-            }
-            else {
-              OBJ_OWNED_BY(GET_QUEST_OBJ(ch)) = NULL;
-            }
-          }
-
-          GET_QUEST_GIVER(ch) = NULL;
-          GET_QUEST_MOB(ch) = NULL;
-          GET_QUEST_OBJ(ch) = NULL;
-          GET_QUEST_LEVEL(ch) = 0;
-          GET_QUEST_STATUS(ch) = QUEST_FAILED;
-          GET_QUEST_TIMER(ch) = 1;
+          aq_fail_quest(ch, QUEST_FAILED);
 
           printf_to_char(ch, "Your time has expired, you have failed your quest! You can start another in %d ticks.\n\r", GET_QUEST_TIMER(ch));
         }

--- a/src/magic.c
+++ b/src/magic.c
@@ -2595,22 +2595,22 @@ void spell_disenchant(ubyte level, CHAR *ch, CHAR *victim, OBJ *obj) {
   }
 }
 
-void spell_petrify(ubyte level, CHAR *ch, CHAR *victim, OBJ *obj) {
+void spell_petrify(ubyte level, CHAR *ch, CHAR *victim, bool skip_msg) {
   if (!spell_check_cast_ok(ch, victim, NO_CAST_SAFE_ROOM)) return;
 
   if (signal_char(victim, ch, MSG_STONE, "")) return;
 
   if (IS_IMMORTAL(victim) && (GET_LEVEL(victim) > GET_LEVEL(ch)) && IS_SET(GET_IMM_FLAGS(victim), WIZ_ACTIVE)) {
-    act("You gaze at $N and you turn to stone!", FALSE, ch, 0, victim, TO_CHAR);
-    act("$n gazes at you and $e turn to stone!", FALSE, ch, 0, victim, TO_VICT);
-    act("$n gazes at $N and $e turns to stone.", FALSE, ch, 0, victim, TO_NOTVICT);
-
+    if (!skip_msg) { // show default petrify messages
+      act("You gaze at $N and you turn to stone!", FALSE, ch, 0, victim, TO_CHAR);
+      act("$n gazes at you and $e turn to stone!", FALSE, ch, 0, victim, TO_VICT);
+      act("$n gazes at $N and $e turns to stone.", FALSE, ch, 0, victim, TO_NOTVICT);
+    }
     CHAR *temp = ch;
-
     ch = victim;
     victim = temp;
   }
-  else {
+  else if (!skip_msg) { // show default petrify messages
     act("You gaze at $N and $E turns to stone!", FALSE, ch, 0, victim, TO_CHAR);
     act("$n gazes at you and you turn to stone!", FALSE, ch, 0, victim, TO_VICT);
     act("$n gazes at $N and $E turns to stone.", FALSE, ch, 0, victim, TO_NOTVICT);

--- a/src/reception.c
+++ b/src/reception.c
@@ -20,6 +20,7 @@
 #include "utils.h"
 #include "spells.h"
 #include "cmd.h"
+#include "aquest.h"
 #include "utility.h"
 #include "reception.h"
 #include "enchant.h"
@@ -457,11 +458,14 @@ void load_char(CHAR *ch) {
   if(signal_char(ch,ch,MSG_OBJ_ENTERING_GAME,buf))
     log_s("Error: Return TRUE from MSG_OBJ_ENTERING_GAME");
 
-  if (ch->ver3.time_to_quest > 0) {
-    ch->ver3.time_to_quest = MAX(ch->ver3.time_to_quest - 40, 5);
-  }
-  else {
-    ch->ver3.time_to_quest = 0;
+  /* If the player reconnects still mid-quest (e.g. they disconnected or
+     the server crashed without going through an explicit failure path),
+     treat it as an interrupted quest and apply the standard cooldown.
+     Otherwise leave time_to_quest exactly as it was already set by
+     aq_fail_quest() at whatever point the quest actually ended --
+     don't re-decay a value that's already final. */
+  if (ch->quest_status == QUEST_RUNNING || ch->quest_status == QUEST_COMPLETED) {
+    aq_fail_quest(ch, QUEST_FAILED);
   }
 
   /* Default all imms gold to 10000 coins - Ranger Sept 97 */
@@ -944,33 +948,37 @@ int receptionist(CHAR *recep,CHAR *ch, int cmd, char *arg) {
       if(ch->quest_status==QUEST_FAILED) {
         printf_to_char(ch,"You have failed your quest, you can start another in %d ticks.\n\r",ch->ver3.time_to_quest);
       }
-      if(ch->quest_status==QUEST_RUNNING || ch->quest_status==QUEST_COMPLETED) {
-        int ttq = MAX(ch->ver3.time_to_quest - 40, 5);
-        snprintf(buf, sizeof(buf), "Your quest has been automatically ended.  You can start another in %d ticks.\n\r", ttq);
-        send_to_char(buf, ch);
-        ch->ver3.time_to_quest=30;
-      }
 
-      ch->questgiver=0;
-      if(ch->questobj)
-      {
-        if(V_OBJ(ch->questobj) == 35)
-        {
-          for(tmp_obj = object_list; tmp_obj; tmp_obj = tmp_obj->next)
-          {
-            if(V_OBJ(tmp_obj) != 35) continue; //not a questcard? skip
-            if(OBJ_SPEC(tmp_obj) != ch->ver3.id) continue; //not the char's questcard? skip
-            extract_obj(tmp_obj);
-          }
-        }
-        else
-          ch->questobj->owned_by=0;
+      if(ch->quest_status==QUEST_RUNNING || ch->quest_status==QUEST_COMPLETED) {
+        /* actually interrupting a quest -- apply the standard cooldown,
+           this also clears questgiver/questobj/questmob for us */
+        aq_fail_quest(ch, QUEST_NONE);
+        printf_to_char(ch, "Your quest has been automatically ended.  You can start another in %d ticks.\n\r", ch->ver3.time_to_quest);
       }
-      ch->questobj=0;
-      if(ch->questmob) ch->questmob->questowner=0;
-      ch->questmob=0;
-      ch->quest_status=QUEST_NONE;
-      ch->quest_level=0;
+      else {
+        /* already failed or no quest at all -- just clear any stale
+           pointers, don't touch the existing cooldown */
+        ch->questgiver=0;
+        if(ch->questobj)
+        {
+          if(V_OBJ(ch->questobj) == 35)
+          {
+            for(tmp_obj = object_list; tmp_obj; tmp_obj = tmp_obj->next)
+            {
+              if(V_OBJ(tmp_obj) != 35) continue; //not a questcard? skip
+              if(OBJ_SPEC(tmp_obj) != ch->ver3.id) continue; //not the char's questcard? skip
+              extract_obj(tmp_obj);
+            }
+          }
+          else
+            ch->questobj->owned_by=0;
+        }
+        ch->questobj=0;
+        if(ch->questmob) ch->questmob->questowner=0;
+        ch->questmob=0;
+        ch->quest_status=QUEST_NONE;
+        ch->quest_level=0;
+      }
 
       act("$n stores your stuff in the safe, and helps you into your chamber.",
            FALSE, recep, 0, ch, TO_VICT);
@@ -1043,29 +1051,31 @@ void auto_rent(CHAR *ch) {
     log_s(buf);
   }
 
-  if(ch->quest_status==QUEST_RUNNING || ch->quest_status==QUEST_COMPLETED)
-    ch->ver3.time_to_quest = MAX(ch->ver3.time_to_quest - 40, 5);
-
-  ch->questgiver=0;
-  if(ch->questobj)
-  {
-    if(V_OBJ(ch->questobj) == 35)
-    {
-      for(tmp_obj = object_list; tmp_obj; tmp_obj = tmp_obj->next)
-      {
-        if(V_OBJ(tmp_obj) != 35) continue; //not a questcard? skip
-        if(OBJ_SPEC(tmp_obj) != ch->ver3.id) continue; //not the char's questcard? skip
-        extract_obj(tmp_obj);
-      }
-    }
-    else
-      ch->questobj->owned_by=0;
+  if(ch->quest_status==QUEST_RUNNING || ch->quest_status==QUEST_COMPLETED) {
+    aq_fail_quest(ch, QUEST_NONE);
   }
-  ch->questobj=0;
-  if(ch->questmob) ch->questmob->questowner=0;
-  ch->questmob=0;
-  ch->quest_status=QUEST_NONE;
-  ch->quest_level=0;
+  else {
+    ch->questgiver=0;
+    if(ch->questobj)
+    {
+      if(V_OBJ(ch->questobj) == 35)
+      {
+        for(tmp_obj = object_list; tmp_obj; tmp_obj = tmp_obj->next)
+        {
+          if(V_OBJ(tmp_obj) != 35) continue; //not a questcard? skip
+          if(OBJ_SPEC(tmp_obj) != ch->ver3.id) continue; //not the char's questcard? skip
+          extract_obj(tmp_obj);
+        }
+      }
+      else
+        ch->questobj->owned_by=0;
+    }
+    ch->questobj=0;
+    if(ch->questmob) ch->questmob->questowner=0;
+    ch->questmob=0;
+    ch->quest_status=QUEST_NONE;
+    ch->quest_level=0;
+  }
   signal_char(ch, ch, MSG_AUTORENT, "");
 
   save_char(ch, world[CHAR_REAL_ROOM(ch)].number);

--- a/src/score.c
+++ b/src/score.c
@@ -2,7 +2,6 @@
   score.c - Improved do_score() and related functions
 
   Written by Alan K. Miles for RoninMUD
-  Last Modification Date: 12/06/2017
 */
 
 #include <stdio.h>
@@ -35,650 +34,565 @@ extern int mana_gain(CHAR *ch);
 extern int move_gain(CHAR *ch);
 extern int check_subclass(CHAR *ch, int sub, int lvl);
 
-void score_query(CHAR *ch, int query, bool opt_text, bool new_line)
-{
-  char buf[MSL];
-  char buf2[MSL];
+void score_query(CHAR *ch, int query, bool opt_text, bool new_line) {
+  char buf[MSL] = {0};
+  char buf2[MIL] = {0};
 
-  sprintf(buf, "%s", "");
-  sprintf(buf2, "%s", "");
-
-  switch (query)
-  {
-  case SCQ_NAME:
-    sprintf(buf, "%sName:%s %s",
-      CHCLR(ch, 7), ENDCHCLR(ch),
-      !IS_NPC(ch) ? GET_NAME(ch) ? GET_NAME(ch) : "(null)" : GET_SHORT(ch) ? GET_SHORT(ch) : "(null)");
-    break;
-  case SCQ_TITLE:
-    sprintf(buf, "%sTitle:%s %s",
-      CHCLR(ch, 7), ENDCHCLR(ch),
-      GET_TITLE(ch) ? GET_TITLE(ch) : "(no title)");
-    break;
-  case SCQ_LEVEL:
-  case SCQ_CLASS_NAME:
-    sprintf(buf, "%sLevel: [%s%d%s]%s %s",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_LEVEL(ch),
-      CHCLR(ch, 7), ENDCHCLR(ch),
-      ((!IS_NPC(ch) && GET_CLASS(ch) > CLASS_NONE && GET_CLASS(ch) <= CLASS_LAST) ||
-       (IS_NPC(ch) && GET_CLASS(ch) >= CLASS_OTHER && GET_CLASS(ch) <= CLASS_MOB_LAST)) ?
-        GET_CLASS_NAME(ch) : "Undefined");
-    break;
-  case SCQ_SC_LEVEL:
-  case SCQ_SC_NAME:
-    if (GET_SC(ch) > SC_NONE && GET_SC(ch) <= SC_LAST)
-    {
-      sprintf(buf, "%sSubclass: [%s%d%s]%s %s",
-        CHCLR(ch, 7), ENDCHCLR(ch),
-        GET_SC_LEVEL(ch),
-        CHCLR(ch, 7), ENDCHCLR(ch),
-        GET_SC_NAME(ch) ? GET_SC_NAME(ch) : "None");
-    }
-    else
-    {
-      sprintf(buf, "%sSubclass:%s None",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-    }
-    break;
-  case SCQ_RANK_LEVEL:
-  case SCQ_RANK_NAME:
-    if (get_rank(ch))
-    {
-      sprintf(buf, "%sRank: [%s%d%s]%s %s",
-        CHCLR(ch, 7), ENDCHCLR(ch),
-        get_rank(ch),
-        CHCLR(ch, 7), ENDCHCLR(ch),
-        get_rank_name(ch));
-    }
-    else
-    {
-      sprintf(buf, "%sRank:%s None",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-    }
-    break;
-  case SCQ_PRESTIGE_LEVEL:
-  case SCQ_PRESTIGE:
-    sprintf(buf, "%sPrestige: [%s%d%s]%s",
-      CHCLR(ch, 7), ENDCHCLR(ch),
-      GET_PRESTIGE(ch),
-      CHCLR(ch, 7), ENDCHCLR(ch));
-    break;
-  case SCQ_MAX_HIT:
-    if (opt_text)
-      sprintf(buf, "%sMaximum%s ",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-
-    sprintf(buf2, "%sHP: [%s%5d%s]%s",
-      CHCLR(ch, 7), ENDCHCLR(ch),
-      GET_MAX_HIT(ch),
-      CHCLR(ch, 7), ENDCHCLR(ch));
-
-    strcat(buf, buf2);
-    break;
-  case SCQ_MAX_MANA:
-    if (opt_text)
-      sprintf(buf, "%sMaximum%s ",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-
-    sprintf(buf2, "%sMana: [%s%5d%s]%s",
-      CHCLR(ch, 7), ENDCHCLR(ch),
-      GET_MAX_MANA(ch),
-      CHCLR(ch, 7), ENDCHCLR(ch));
-
-    strcat(buf, buf2);
-    break;
-  case SCQ_MAX_MOVE:
-    if (opt_text)
-      sprintf(buf, "%sMaximum%s ",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-
-    sprintf(buf, "%sMove: [%s%5d%s]%s",
-      CHCLR(ch, 7), ENDCHCLR(ch),
-      GET_MAX_MOVE(ch),
-      CHCLR(ch, 7), ENDCHCLR(ch));
-
-    strcat(buf, buf2);
-    break;
-  case SCQ_NAT_HIT:
-    if (opt_text)
-      sprintf(buf, "%sNatural%s ",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-
-    sprintf(buf2, "%sHP: [%s%5d%s]%s",
-      CHCLR(ch, 7), ENDCHCLR(ch),
-      GET_NAT_HIT(ch),
-      CHCLR(ch, 7), ENDCHCLR(ch));
-
-    strcat(buf, buf2);
-    break;
-  case SCQ_NAT_MANA:
-    if (opt_text)
-      sprintf(buf, "%sNatural%s ",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-
-    sprintf(buf2, "%sMana: [%s%5d%s]%s",
-      CHCLR(ch, 7), ENDCHCLR(ch),
-      GET_NAT_MANA(ch),
-      CHCLR(ch, 7), ENDCHCLR(ch));
-
-    strcat(buf, buf2);
-    break;
-  case SCQ_NAT_MOVE:
-    if (opt_text)
-      sprintf(buf, "%sNatural%s ",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-
-    sprintf(buf2, "%sMove: [%s%5d%s]%s",
-      CHCLR(ch, 7), ENDCHCLR(ch),
-      GET_NAT_MOVE(ch),
-      CHCLR(ch, 7), ENDCHCLR(ch));
-
-    strcat(buf, buf2);
-    break;
-  case SCQ_HIT_GAIN:
-    if (opt_text)
-      sprintf(buf, "%sGain +- HP:%s ",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-    else
-      sprintf(buf, "%sHP:%s  ",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-
-    sprintf(buf2, "%+-13d", hit_gain(ch));
-
-    strcat(buf, buf2);
-    break;
-  case SCQ_MANA_GAIN:
-    if (opt_text)
-      sprintf(buf, "%sGain +- Mana:%s ",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-    else
-      sprintf(buf, "%sMana:%s  ",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-
-    sprintf(buf2, "%+-13d", mana_gain(ch));
-
-    strcat(buf, buf2);
-    break;
-  case SCQ_MOVE_GAIN:
-    if (opt_text)
-      sprintf(buf, "%sGain +- Move:%s ",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-    else
-      sprintf(buf, "%sMove:%s  ",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-
-    sprintf(buf2, "%+-13d", move_gain(ch));
-
-    strcat(buf, buf2);
-    break;
-  case SCQ_STR:
-    if (opt_text)
-      sprintf(buf, "%sCurrent STR:%s ",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-
-    if (GET_LEVEL(ch) < 6)
-      strcat(buf, "--");
-    else
-    {
-      sprintf(buf2, "%-2d", GET_STR(ch));
-      strcat(buf, buf2);
-
-      if (GET_STR(ch) == 18)
-      {
-        sprintf(buf2, "/%-3d", GET_ADD(ch));
-        strcat(buf, buf2);
+  switch (query) {
+    case SCQ_NAME:
+      snprintf(buf, sizeof(buf), "%sName:%s %s", CHCLR(ch, 7), ENDCHCLR(ch),
+               !IS_NPC(ch)     ? GET_NAME(ch) ? GET_NAME(ch) : "(null)"
+               : GET_SHORT(ch) ? GET_SHORT(ch)
+                               : "(null)");
+      break;
+    case SCQ_TITLE:
+      snprintf(buf, sizeof(buf), "%sTitle:%s %s", CHCLR(ch, 7), ENDCHCLR(ch), GET_TITLE(ch) ? GET_TITLE(ch) : "(no title)");
+      break;
+    case SCQ_LEVEL:
+    case SCQ_CLASS_NAME:
+      snprintf(buf, sizeof(buf), "%sLevel: [%s%d%s]%s %s", CHCLR(ch, 7), ENDCHCLR(ch), GET_LEVEL(ch), CHCLR(ch, 7), ENDCHCLR(ch),
+               ((!IS_NPC(ch) && GET_CLASS(ch) > CLASS_NONE && GET_CLASS(ch) <= CLASS_LAST) ||
+                (IS_NPC(ch) && GET_CLASS(ch) >= CLASS_OTHER && GET_CLASS(ch) <= CLASS_MOB_LAST))
+                   ? GET_CLASS_NAME(ch)
+                   : "Undefined");
+      break;
+    case SCQ_SC_LEVEL:
+    case SCQ_SC_NAME:
+      if (GET_SC(ch) > SC_NONE && GET_SC(ch) <= SC_LAST) {
+        snprintf(buf, sizeof(buf), "%sSubclass: [%s%d%s]%s %s", CHCLR(ch, 7), ENDCHCLR(ch), GET_SC_LEVEL(ch), CHCLR(ch, 7), ENDCHCLR(ch),
+                 GET_SC_NAME(ch) ? GET_SC_NAME(ch) : "None");
+      } else {
+        snprintf(buf, sizeof(buf), "%sSubclass:%s None", CHCLR(ch, 7), ENDCHCLR(ch));
       }
-    }
-    break;
-  case SCQ_DEX:
-    if (opt_text)
-      sprintf(buf, "%sCurrent DEX:%s ",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-
-    if (GET_LEVEL(ch) < 6)
-      strcat(buf, "--");
-    else
-    {
-      sprintf(buf2, "%-2d", GET_DEX(ch));
-      strcat(buf, buf2);
-    }
-    break;
-  case SCQ_CON:
-    if (opt_text)
-      sprintf(buf, "%sCurrent CON:%s ",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-
-    if (GET_LEVEL(ch) < 6)
-      strcat(buf, "--");
-    else
-    {
-      sprintf(buf2, "%-2d", GET_CON(ch));
-      strcat(buf, buf2);
-    }
-    break;
-  case SCQ_INT:
-    if (opt_text)
-      sprintf(buf, "%sCurrent INT:%s ",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-
-    if (GET_LEVEL(ch) < 6)
-      strcat(buf, "--");
-    else
-    {
-      sprintf(buf2, "%-2d", GET_INT(ch));
-      strcat(buf, buf2);
-    }
-    break;
-  case SCQ_WIS:
-    if (opt_text)
-      sprintf(buf, "%sCurrent WIS:%s ",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-
-    if (GET_LEVEL(ch) < 6)
-      strcat(buf, "--");
-    else
-    {
-      sprintf(buf2, "%-2d", GET_WIS(ch));
-      strcat(buf, buf2);
-    }
-    break;
-  case SCQ_OSTR:
-    if (opt_text)
-      sprintf(buf, "%sNatural STR:%s ",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-
-    if (GET_LEVEL(ch) < 6)
-      strcat(buf, "--");
-    else
-    {
-      sprintf(buf2, "%-2d", GET_OSTR(ch));
-      strcat(buf, buf2);
-
-      if (GET_OSTR(ch) == 18)
-      {
-        sprintf(buf2, "/%-3d", GET_OADD(ch));
-        strcat(buf, buf2);
+      break;
+    case SCQ_RANK_LEVEL:
+    case SCQ_RANK_NAME:
+      if (get_rank(ch)) {
+        snprintf(buf, sizeof(buf), "%sRank: [%s%d%s]%s %s", CHCLR(ch, 7), ENDCHCLR(ch), get_rank(ch), CHCLR(ch, 7), ENDCHCLR(ch), get_rank_name(ch));
+      } else {
+        snprintf(buf, sizeof(buf), "%sRank:%s None", CHCLR(ch, 7), ENDCHCLR(ch));
       }
-    }
-    break;
-  case SCQ_ODEX:
-    if (opt_text)
-      sprintf(buf, "%sNatural DEX:%s ",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-
-    if (GET_LEVEL(ch) < 6)
-      strcat(buf, "--");
-    else
-    {
-      sprintf(buf2, "%-2d", GET_ODEX(ch));
-      strcat(buf, buf2);
-    }
-    break;
-  case SCQ_OCON:
-    if (opt_text)
-      sprintf(buf, "%sNatural CON:%s ",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-
-    if (GET_LEVEL(ch) < 6)
-      strcat(buf, "--");
-    else
-    {
-      sprintf(buf2, "%-2d", GET_OCON(ch));
-      strcat(buf, buf2);
-    }
-    break;
-  case SCQ_OINT:
-    if (opt_text)
-      sprintf(buf, "%sNatural INT:%s ",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-
-    if (GET_LEVEL(ch) < 6)
-      strcat(buf, "--");
-    else
-    {
-      sprintf(buf2, "%-2d", GET_OINT(ch));
-      strcat(buf, buf2);
-    }
-    break;
-  case SCQ_OWIS:
-    if (opt_text)
-      sprintf(buf, "%sNatural WIS:%s ",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-
-    if (GET_LEVEL(ch) < 6)
-      strcat(buf, "--");
-    else
-    {
-      sprintf(buf2, "%-2d", GET_OWIS(ch));
-      strcat(buf, buf2);
-    }
-    break;
-  case SCQ_MOD_AC:
-    sprintf(buf, "%sArmor Class:%s %+-13d",
-      CHCLR(ch, 7), ENDCHCLR(ch), calc_ac(ch));
-    break;
-  case SCQ_WIMPY_LIMIT:
-    sprintf(buf, "%sWimpy Limit:%s %-13d",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_WIMPY(ch));
-    break;
-  case SCQ_BLEED_LIMIT:
-    sprintf(buf, "%sBleed Limit:%s %-13d",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_BLEED(ch));
-    break;
-  case SCQ_SCP:
-    sprintf(buf, "%sSubclass Pts:%s %-13d",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_SCP(ch));
-    break;
-  case SCQ_QP:
-    sprintf(buf, "%sQuest Points:%s %-13d",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_QP(ch));
-    break;
-  case SCQ_RANKING:
-    sprintf(buf, "%sClass Points:%s %-13d",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_RANKING(ch));
-    break;
-  case SCQ_BEEN_KILLED:
-    sprintf(buf, "%sTotal Deaths:%s %-13d",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_BEEN_KILLED(ch));
-    break;
-  case SCQ_AGE:
-    sprintf(buf, "%sAge in Years:%s %-13d",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_AGE(ch));
-    break;
-  case SCQ_PRAC:
-    sprintf(buf, "%sPractices:%s %-13d",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_PRAC(ch));
-    break;
-  case SCQ_AVG_DAMAGE:
-    sprintf(buf, "%sAverage Damage:%s ",
-      CHCLR(ch, 7), ENDCHCLR(ch));
-
-    if ((GET_CLASS(ch) == CLASS_NINJA) || (IS_MORTAL(ch) && check_subclass(ch, SC_MERCENARY, 5)))
-      sprintf(buf2, "%d / %d",
-        calc_hit_damage(ch, NULL, GET_WEAPON(ch), 0, RND_AVG),
-        calc_hit_damage(ch, NULL, GET_WEAPON2(ch), 0, RND_AVG));
-    else
-      sprintf(buf2, "%d",
-        calc_hit_damage(ch, NULL, GET_WEAPON(ch), 0, RND_AVG));
-    strcat(buf, buf2);
-    break;
-  case SCQ_DAMROLL:
-    sprintf(buf, "%sDamroll:%s %+-13d",
-      CHCLR(ch, 7), ENDCHCLR(ch), calc_damroll(ch));
-    break;
-  case SCQ_HITROLL:
-    sprintf(buf, "%sHitroll:%s %+-13d",
-      CHCLR(ch, 7), ENDCHCLR(ch), calc_hitroll(ch));
-    break;
-  case SCQ_ALIGNMENT:
-    sprintf(buf, "%sAlignment:%s %d ",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_ALIGNMENT(ch));
-
-    if (GET_ALIGNMENT(ch) >= 750)
-      strcat(buf, "(Saintly)");
-    else if (GET_ALIGNMENT(ch) >= 350)
-      strcat(buf, "(Good)");
-    else if (GET_ALIGNMENT(ch) > -350)
-      strcat(buf, "(Neutral)");
-    else if (GET_ALIGNMENT(ch) > -750)
-      strcat(buf, "(Evil)");
-    else
-      strcat(buf, "(Prime Evil)");
-    break;
-  case SCQ_EXP:
-    sprintf(buf, "%sExperience:%s %-13d",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_EXP(ch));
-    break;
-  case SCQ_EXP_TO_LEVEL:
-    if (GET_LEVEL(ch) < LEVEL_MORT)
-      sprintf(buf, "%sXP to Level:%s %-13d",
-        CHCLR(ch, 7), ENDCHCLR(ch), GET_EXP_TO_LEVEL(ch));
-    else
-      sprintf(buf, "%sXP to Level:%s Max Level",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-    break;
-  case SCQ_REMORT_EXP:
-    sprintf(buf, "%sRemort XP:%s %-13ld",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_REMORT_EXP(ch));
-    break;
-  case SCQ_REMORT_MULT:
-    sprintf(buf, "%sRemort Multiplier:%s %d",
-      CHCLR(ch, 7), ENDCHCLR(ch), rv2_calc_remort_mult(ch));
-    break;
-  case SCQ_DEATH_EXP:
-    sprintf(buf, "%sDeath XP:%s %-13u",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_DEATH_EXP(ch));
-    break;
-  case SCQ_GOLD:
-    sprintf(buf, "%sGold Carried:%s %-13d",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_GOLD(ch));
-    break;
-  case SCQ_BANK:
-    sprintf(buf, "%sGold in Bank:%s %-13d",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_BANK(ch));
-    break;
-  case SCQ_QUEST_TIMER:
-    if (GET_QUEST_STATUS(ch) == QUEST_NONE && !GET_QUEST_TIMER(ch))
-      sprintf(buf, "%sQuest Timer:%s None",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-    else
-      sprintf(buf, "%sQuest Timer:%s %s in %d Tick%s",
-        CHCLR(ch, 7), ENDCHCLR(ch),
-        GET_QUEST_STATUS(ch) == QUEST_RUNNING ? "Expires" : "Next",
-        GET_QUEST_TIMER(ch), GET_QUEST_TIMER(ch) == 1 ? "" : "s");
-    break;
-  case SCQ_CLUB:
-    sprintf(buf, "%sMember of Club:%s ",
-      CHCLR(ch, 7), ENDCHCLR(ch));
-
-    if (IS_SET(GET_PFLAG(ch), PLR_SANES_VOCAL_CLUB))
-      strcat(buf, "Sane's Vocal Club");
-    else if (IS_SET(GET_PFLAG(ch), PLR_LINERS_LOUNGE))
-      strcat(buf, "Liner's Lounge");
-    else if (IS_SET(GET_PFLAG(ch), PLR_LEMS_LIQOUR_ROOM))
-      strcat(buf, "Lem's Liqour Room");
-    else if (IS_SET(GET_PFLAG(ch), PLR_RANGERS_RELIQUARY))
-      strcat(buf, "Ranger's Reliquary");
-    else
-      strcat(buf, "None");
-    break;
-  case SCQ_CLAN:
-    sprintf(buf, "%sClan/Guild:%s %s",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_CLAN_NAME(ch));
-    break;
-  case SCQ_PLAY_TIME:
-    sprintf(buf, "%sTime Played:%s %d Day%s, %d Hour%s",
-      CHCLR(ch, 7), ENDCHCLR(ch),
-      GET_PLAY_TIME(ch).day, GET_PLAY_TIME(ch).day == 1 ? "" : "s",
-      GET_PLAY_TIME(ch).hours, GET_PLAY_TIME(ch).hours == 1 ? "" : "s");
-    break;
-  case SCQ_WEIGHT_CARRIED:
-    sprintf(buf, "%sWeight Carried:%s %d of %d",
-      CHCLR(ch, 7), ENDCHCLR(ch), IS_CARRYING_W(ch), CAN_CARRY_W(ch));
-    break;
-  case SCQ_TOGGLES:
-    sprintf(buf, "%sToggles:%s",
-      CHCLR(ch, 7), ENDCHCLR(ch));
-
-    if (!IS_NPC(ch) && GET_PFLAG(ch))
-    {
-      if (IS_SET(GET_PFLAG(ch), PLR_NOKILL))
-        strcat(buf, " NO_KILL");
-      if (IS_SET(GET_PFLAG(ch), PLR_NOMESSAGE))
-        strcat(buf, " NO_MESSAGE");
-      if (IS_SET(GET_PFLAG(ch), PLR_NOSUMMON))
-        strcat(buf, " NO_SUMMON");
-      if (IS_SET(GET_PFLAG(ch), PLR_GOSSIP))
-        strcat(buf, " GOSSIP");
-      if (IS_SET(GET_PFLAG(ch), PLR_AUCTION))
-        strcat(buf, " AUCTION");
-      if (IS_SET(GET_PFLAG(ch), PLR_CHAOS))
-        strcat(buf, " CHAOS");
-      if (IS_SET(GET_PFLAG(ch), PLR_QUESTC))
-        strcat(buf, " Q-CHANNEL");
-      if (IS_SET(GET_PFLAG(ch), PLR_QUEST))
-        strcat(buf, " Q-PLAYER");
-      if (IS_SET(GET_PFLAG(ch), PLR_QUIET))
-        strcat(buf, " Q-QUIET");
-      if (IS_SET(GET_PFLAG(ch), PLR_REMORT_DISABLED))
-        strcat(buf, " REMORT_DISABLED");
-    }
-    else
-      strcat(buf, " None");
-    break;
-  case SCQ_FLAGS:
-    if (!IS_NPC(ch) &&
-        (IS_SET(GET_PFLAG(ch), PLR_DEPUTY) ||
-         GET_COND(ch, DRUNK) > 10 ||
-         IS_SET(GET_PFLAG(ch), PLR_KILL) ||
-         IS_SET(GET_PFLAG(ch), PLR_THIEF)))
-    {
-      if (IS_SET(GET_PFLAG(ch), PLR_DEPUTY))
-      {
-        sprintf(buf2, "%sYou are a Midgaard Deputy.%s\n\r",
-          CHCLR(ch, 7), ENDCHCLR(ch));
-        strcat(buf, buf2);
+      break;
+    case SCQ_PRESTIGE_LEVEL:
+    case SCQ_PRESTIGE:
+      snprintf(buf, sizeof(buf), "%sPrestige: [%s%d%s]%s", CHCLR(ch, 7), ENDCHCLR(ch), GET_PRESTIGE(ch), CHCLR(ch, 7), ENDCHCLR(ch));
+      break;
+    case SCQ_MAX_HIT:
+      if (opt_text) {
+        snprintf(buf, sizeof(buf), "%sMaximum%s ", CHCLR(ch, 7), ENDCHCLR(ch));
       }
 
-      if (GET_COND(ch, DRUNK) > 10)
-      {
-        sprintf(buf2, "%sYou are intoxicated.%s\n\r",
-          CHCLR(ch, 7), ENDCHCLR(ch));
-        strcat(buf, buf2);
+      snprintf(buf2, sizeof(buf2), "%sHP: [%s%5d%s]%s", CHCLR(ch, 7), ENDCHCLR(ch), GET_MAX_HIT(ch), CHCLR(ch, 7), ENDCHCLR(ch));
+
+      str_cat(buf, sizeof(buf), buf2);
+      break;
+    case SCQ_MAX_MANA:
+      if (opt_text) {
+        snprintf(buf, sizeof(buf), "%sMaximum%s ", CHCLR(ch, 7), ENDCHCLR(ch));
       }
 
-      if (IS_SET(GET_PFLAG(ch), PLR_KILL))
-      {
-        sprintf(buf2, "%sYou are a killer.%s\n\r",
-          CHCLR(ch, 7), ENDCHCLR(ch));
-        strcat(buf, buf2);
+      snprintf(buf2, sizeof(buf2), "%sMana: [%s%5d%s]%s", CHCLR(ch, 7), ENDCHCLR(ch), GET_MAX_MANA(ch), CHCLR(ch, 7), ENDCHCLR(ch));
+
+      str_cat(buf, sizeof(buf), buf2);
+      break;
+    case SCQ_MAX_MOVE:
+      if (opt_text) {
+        snprintf(buf, sizeof(buf), "%sMaximum%s ", CHCLR(ch, 7), ENDCHCLR(ch));
       }
 
-      if (IS_SET(GET_PFLAG(ch), PLR_THIEF))
-      {
-        sprintf(buf2, "%sYou are a thief.%s\n\r",
-          CHCLR(ch, 7), ENDCHCLR(ch));
-        strcat(buf, buf2);
+      snprintf(buf, sizeof(buf), "%sMove: [%s%5d%s]%s", CHCLR(ch, 7), ENDCHCLR(ch), GET_MAX_MOVE(ch), CHCLR(ch, 7), ENDCHCLR(ch));
+
+      str_cat(buf, sizeof(buf), buf2);
+      break;
+    case SCQ_NAT_HIT:
+      if (opt_text) {
+        snprintf(buf, sizeof(buf), "%sNatural%s ", CHCLR(ch, 7), ENDCHCLR(ch));
       }
-    }
-    else
-      sprintf(buf, "%sFlags:%s None\n\r",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-    break;
-  case SCQ_DEATH_LIMIT:
-    if (GET_DEATH_LIMIT(ch))
-      sprintf(buf, "%sAfter%s %d %sdeaths you will lose stats regardless.%s",
-        CHCLR(ch, 7), ENDCHCLR(ch), GET_DEATH_LIMIT(ch), CHCLR(ch, 7), ENDCHCLR(ch));
-    else if (opt_text)
-      sprintf(buf, "%sYou are not affected by a death limit.%s",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-    break;
-  case SCQ_POSITION:
-    switch (GET_POS(ch))
-    {
-    case POSITION_DEAD:
-      sprintf(buf, "%sYou are DEAD!%s",
-        CHCLR(ch, 7), ENDCHCLR(ch));
+
+      snprintf(buf2, sizeof(buf2), "%sHP: [%s%5d%s]%s", CHCLR(ch, 7), ENDCHCLR(ch), GET_NAT_HIT(ch), CHCLR(ch, 7), ENDCHCLR(ch));
+
+      str_cat(buf, sizeof(buf), buf2);
       break;
-    case POSITION_MORTALLYW:
-      sprintf(buf, "%sYou are mortally wounded! You should seek help!%s",
-        CHCLR(ch, 7), ENDCHCLR(ch));
+    case SCQ_NAT_MANA:
+      if (opt_text) {
+        snprintf(buf, sizeof(buf), "%sNatural%s ", CHCLR(ch, 7), ENDCHCLR(ch));
+      }
+
+      snprintf(buf2, sizeof(buf2), "%sMana: [%s%5d%s]%s", CHCLR(ch, 7), ENDCHCLR(ch), GET_NAT_MANA(ch), CHCLR(ch, 7), ENDCHCLR(ch));
+
+      str_cat(buf, sizeof(buf), buf2);
       break;
-    case POSITION_INCAP:
-      sprintf(buf, "%sYou are incapacitated, slowly fading away...%s",
-        CHCLR(ch, 7), ENDCHCLR(ch));
+    case SCQ_NAT_MOVE:
+      if (opt_text) {
+        snprintf(buf, sizeof(buf), "%sNatural%s ", CHCLR(ch, 7), ENDCHCLR(ch));
+      }
+
+      snprintf(buf2, sizeof(buf2), "%sMove: [%s%5d%s]%s", CHCLR(ch, 7), ENDCHCLR(ch), GET_NAT_MOVE(ch), CHCLR(ch, 7), ENDCHCLR(ch));
+
+      str_cat(buf, sizeof(buf), buf2);
       break;
-    case POSITION_STUNNED:
-      sprintf(buf, "%sYou are stunned! You can't move!%s",
-        CHCLR(ch, 7), ENDCHCLR(ch));
+    case SCQ_HIT_GAIN:
+      if (opt_text) {
+        snprintf(buf, sizeof(buf), "%sGain +- HP:%s ", CHCLR(ch, 7), ENDCHCLR(ch));
+      } else {
+        snprintf(buf, sizeof(buf), "%sHP:%s  ", CHCLR(ch, 7), ENDCHCLR(ch));
+      }
+
+      snprintf(buf2, sizeof(buf2), "%+-13d", hit_gain(ch));
+
+      str_cat(buf, sizeof(buf), buf2);
       break;
-    case POSITION_SLEEPING:
-      sprintf(buf, "%sYou are sleeping.%s",
-        CHCLR(ch, 7), ENDCHCLR(ch));
+    case SCQ_MANA_GAIN:
+      if (opt_text) {
+        snprintf(buf, sizeof(buf), "%sGain +- Mana:%s ", CHCLR(ch, 7), ENDCHCLR(ch));
+      } else {
+        snprintf(buf, sizeof(buf), "%sMana:%s  ", CHCLR(ch, 7), ENDCHCLR(ch));
+      }
+
+      snprintf(buf2, sizeof(buf2), "%+-13d", mana_gain(ch));
+
+      str_cat(buf, sizeof(buf), buf2);
       break;
-    case POSITION_RESTING:
-      sprintf(buf, "%sYou are resting.%s",
-        CHCLR(ch, 7), ENDCHCLR(ch));
+    case SCQ_MOVE_GAIN:
+      if (opt_text) {
+        snprintf(buf, sizeof(buf), "%sGain +- Move:%s ", CHCLR(ch, 7), ENDCHCLR(ch));
+      } else {
+        snprintf(buf, sizeof(buf), "%sMove:%s  ", CHCLR(ch, 7), ENDCHCLR(ch));
+      }
+
+      snprintf(buf2, sizeof(buf2), "%+-13d", move_gain(ch));
+
+      str_cat(buf, sizeof(buf), buf2);
       break;
-    case POSITION_SITTING:
-      sprintf(buf, "%sYou are sitting.%s",
-        CHCLR(ch, 7), ENDCHCLR(ch));
+    case SCQ_STR:
+      if (opt_text) {
+        snprintf(buf, sizeof(buf), "%sCurrent STR:%s ", CHCLR(ch, 7), ENDCHCLR(ch));
+      }
+
+      if (GET_LEVEL(ch) < 6) {
+        str_cat(buf, sizeof(buf), "--");
+      } else {
+        snprintf(buf2, sizeof(buf2), "%-2d", GET_STR(ch));
+        str_cat(buf, sizeof(buf), buf2);
+
+        if (GET_STR(ch) == 18) {
+          snprintf(buf2, sizeof(buf2), "/%-3d", GET_ADD(ch));
+          str_cat(buf, sizeof(buf), buf2);
+        }
+      }
       break;
-    case POSITION_FLYING:
-      sprintf(buf, "%sYou are flying.%s",
-        CHCLR(ch, 7), ENDCHCLR(ch));
+    case SCQ_DEX:
+      if (opt_text) {
+        snprintf(buf, sizeof(buf), "%sCurrent DEX:%s ", CHCLR(ch, 7), ENDCHCLR(ch));
+      }
+
+      if (GET_LEVEL(ch) < 6) {
+        str_cat(buf, sizeof(buf), "--");
+      } else {
+        snprintf(buf2, sizeof(buf2), "%-2d", GET_DEX(ch));
+        str_cat(buf, sizeof(buf), buf2);
+      }
       break;
-    case POSITION_RIDING:
-      sprintf(buf, "%sYou are riding.%s",
-        CHCLR(ch, 7), ENDCHCLR(ch));
+    case SCQ_CON:
+      if (opt_text) {
+        snprintf(buf, sizeof(buf), "%sCurrent CON:%s ", CHCLR(ch, 7), ENDCHCLR(ch));
+      }
+
+      if (GET_LEVEL(ch) < 6) {
+        str_cat(buf, sizeof(buf), "--");
+      } else {
+        snprintf(buf2, sizeof(buf2), "%-2d", GET_CON(ch));
+        str_cat(buf, sizeof(buf), buf2);
+      }
       break;
-    case POSITION_SWIMMING:
-      sprintf(buf, "%sYou are swimming.%s",
-        CHCLR(ch, 7), ENDCHCLR(ch));
+    case SCQ_INT:
+      if (opt_text) {
+        snprintf(buf, sizeof(buf), "%sCurrent INT:%s ", CHCLR(ch, 7), ENDCHCLR(ch));
+      }
+
+      if (GET_LEVEL(ch) < 6) {
+        str_cat(buf, sizeof(buf), "--");
+      } else {
+        snprintf(buf2, sizeof(buf2), "%-2d", GET_INT(ch));
+        str_cat(buf, sizeof(buf), buf2);
+      }
       break;
-    case POSITION_FIGHTING:
-      if (GET_OPPONENT(ch))
-        sprintf(buf, "%sYou are fighting %s.%s",
-          CHCLR(ch, 7),
-          !IS_MOB(GET_OPPONENT(ch)) ?
-          GET_NAME(GET_OPPONENT(ch)) ? GET_NAME(GET_OPPONENT(ch)) : "(null)" :
-          GET_SHORT(GET_OPPONENT(ch)) ? GET_SHORT(GET_OPPONENT(ch)) : "(null)",
-          ENDCHCLR(ch));
-      else
-        sprintf(buf, "%sYou are fighting thin air.%s",
-          CHCLR(ch, 7), ENDCHCLR(ch));
+    case SCQ_WIS:
+      if (opt_text) {
+        snprintf(buf, sizeof(buf), "%sCurrent WIS:%s ", CHCLR(ch, 7), ENDCHCLR(ch));
+      }
+
+      if (GET_LEVEL(ch) < 6) {
+        str_cat(buf, sizeof(buf), "--");
+      } else {
+        snprintf(buf2, sizeof(buf2), "%-2d", GET_WIS(ch));
+        str_cat(buf, sizeof(buf), buf2);
+      }
       break;
-    case POSITION_STANDING:
-      sprintf(buf, "%sYou are standing.%s",
-        CHCLR(ch, 7), ENDCHCLR(ch));
+    case SCQ_OSTR:
+      if (opt_text) {
+        snprintf(buf, sizeof(buf), "%sNatural STR:%s ", CHCLR(ch, 7), ENDCHCLR(ch));
+      }
+
+      if (GET_LEVEL(ch) < 6) {
+        str_cat(buf, sizeof(buf), "--");
+      } else {
+        snprintf(buf2, sizeof(buf2), "%-2d", GET_OSTR(ch));
+        str_cat(buf, sizeof(buf), buf2);
+
+        if (GET_OSTR(ch) == 18) {
+          snprintf(buf2, sizeof(buf2), "/%-3d", GET_OADD(ch));
+          str_cat(buf, sizeof(buf), buf2);
+        }
+      }
       break;
+    case SCQ_ODEX:
+      if (opt_text) {
+        snprintf(buf, sizeof(buf), "%sNatural DEX:%s ", CHCLR(ch, 7), ENDCHCLR(ch));
+      }
+
+      if (GET_LEVEL(ch) < 6) {
+        str_cat(buf, sizeof(buf), "--");
+      } else {
+        snprintf(buf2, sizeof(buf2), "%-2d", GET_ODEX(ch));
+        str_cat(buf, sizeof(buf), buf2);
+      }
+      break;
+    case SCQ_OCON:
+      if (opt_text) {
+        snprintf(buf, sizeof(buf), "%sNatural CON:%s ", CHCLR(ch, 7), ENDCHCLR(ch));
+      }
+
+      if (GET_LEVEL(ch) < 6) {
+        str_cat(buf, sizeof(buf), "--");
+      } else {
+        snprintf(buf2, sizeof(buf2), "%-2d", GET_OCON(ch));
+        str_cat(buf, sizeof(buf), buf2);
+      }
+      break;
+    case SCQ_OINT:
+      if (opt_text) {
+        snprintf(buf, sizeof(buf), "%sNatural INT:%s ", CHCLR(ch, 7), ENDCHCLR(ch));
+      }
+
+      if (GET_LEVEL(ch) < 6) {
+        str_cat(buf, sizeof(buf), "--");
+      } else {
+        snprintf(buf2, sizeof(buf2), "%-2d", GET_OINT(ch));
+        str_cat(buf, sizeof(buf), buf2);
+      }
+      break;
+    case SCQ_OWIS:
+      if (opt_text) {
+        snprintf(buf, sizeof(buf), "%sNatural WIS:%s ", CHCLR(ch, 7), ENDCHCLR(ch));
+      }
+
+      if (GET_LEVEL(ch) < 6) {
+        str_cat(buf, sizeof(buf), "--");
+      } else {
+        snprintf(buf2, sizeof(buf2), "%-2d", GET_OWIS(ch));
+        str_cat(buf, sizeof(buf), buf2);
+      }
+      break;
+    case SCQ_MOD_AC:
+      snprintf(buf, sizeof(buf), "%sArmor Class:%s %+-13d", CHCLR(ch, 7), ENDCHCLR(ch), calc_ac(ch));
+      break;
+    case SCQ_WIMPY_LIMIT:
+      snprintf(buf, sizeof(buf), "%sWimpy Limit:%s %-13d", CHCLR(ch, 7), ENDCHCLR(ch), GET_WIMPY(ch));
+      break;
+    case SCQ_BLEED_LIMIT:
+      snprintf(buf, sizeof(buf), "%sBleed Limit:%s %-13d", CHCLR(ch, 7), ENDCHCLR(ch), GET_BLEED(ch));
+      break;
+    case SCQ_SCP:
+      snprintf(buf, sizeof(buf), "%sSubclass Pts:%s %-13d", CHCLR(ch, 7), ENDCHCLR(ch), GET_SCP(ch));
+      break;
+    case SCQ_QP:
+      snprintf(buf, sizeof(buf), "%sQuest Points:%s %-13d", CHCLR(ch, 7), ENDCHCLR(ch), GET_QP(ch));
+      break;
+    case SCQ_RANKING:
+      snprintf(buf, sizeof(buf), "%sClass Points:%s %-13d", CHCLR(ch, 7), ENDCHCLR(ch), GET_RANKING(ch));
+      break;
+    case SCQ_BEEN_KILLED:
+      snprintf(buf, sizeof(buf), "%sTotal Deaths:%s %-13d", CHCLR(ch, 7), ENDCHCLR(ch), GET_BEEN_KILLED(ch));
+      break;
+    case SCQ_AGE:
+      snprintf(buf, sizeof(buf), "%sAge in Years:%s %-13d", CHCLR(ch, 7), ENDCHCLR(ch), GET_AGE(ch));
+      break;
+    case SCQ_PRAC:
+      snprintf(buf, sizeof(buf), "%sPractices:%s %-13d", CHCLR(ch, 7), ENDCHCLR(ch), GET_PRAC(ch));
+      break;
+    case SCQ_AVG_DAMAGE:
+      snprintf(buf, sizeof(buf), "%sAverage Damage:%s ", CHCLR(ch, 7), ENDCHCLR(ch));
+
+      if ((GET_CLASS(ch) == CLASS_NINJA) || (IS_MORTAL(ch) && check_subclass(ch, SC_MERCENARY, 5))) {
+        snprintf(buf2, sizeof(buf2), "%d / %d", calc_hit_damage(ch, NULL, GET_WEAPON(ch), 0, RND_AVG), calc_hit_damage(ch, NULL, GET_WEAPON2(ch), 0, RND_AVG));
+      } else {
+        snprintf(buf2, sizeof(buf2), "%d", calc_hit_damage(ch, NULL, GET_WEAPON(ch), 0, RND_AVG));
+      }
+      str_cat(buf, sizeof(buf), buf2);
+      break;
+    case SCQ_DAMROLL:
+      snprintf(buf, sizeof(buf), "%sDamroll:%s %+-13d", CHCLR(ch, 7), ENDCHCLR(ch), calc_damroll(ch));
+      break;
+    case SCQ_HITROLL:
+      snprintf(buf, sizeof(buf), "%sHitroll:%s %+-13d", CHCLR(ch, 7), ENDCHCLR(ch), calc_hitroll(ch));
+      break;
+    case SCQ_ALIGNMENT:
+      snprintf(buf, sizeof(buf), "%sAlignment:%s %d ", CHCLR(ch, 7), ENDCHCLR(ch), GET_ALIGNMENT(ch));
+
+      if (GET_ALIGNMENT(ch) >= 750) {
+        str_cat(buf, sizeof(buf), "(Saintly)");
+      } else if (GET_ALIGNMENT(ch) >= 350) {
+        str_cat(buf, sizeof(buf), "(Good)");
+      } else if (GET_ALIGNMENT(ch) > -350) {
+        str_cat(buf, sizeof(buf), "(Neutral)");
+      } else if (GET_ALIGNMENT(ch) > -750) {
+        str_cat(buf, sizeof(buf), "(Evil)");
+      } else {
+        str_cat(buf, sizeof(buf), "(Prime Evil)");
+      }
+      break;
+    case SCQ_EXP:
+      snprintf(buf, sizeof(buf), "%sExperience:%s %-13d", CHCLR(ch, 7), ENDCHCLR(ch), GET_EXP(ch));
+      break;
+    case SCQ_EXP_TO_LEVEL:
+      if (GET_LEVEL(ch) < LEVEL_MORT) {
+        snprintf(buf, sizeof(buf), "%sXP to Level:%s %-13d", CHCLR(ch, 7), ENDCHCLR(ch), GET_EXP_TO_LEVEL(ch));
+      } else {
+        snprintf(buf, sizeof(buf), "%sXP to Level:%s Max Level", CHCLR(ch, 7), ENDCHCLR(ch));
+      }
+      break;
+    case SCQ_REMORT_EXP:
+      snprintf(buf, sizeof(buf), "%sRemort XP:%s %-13ld", CHCLR(ch, 7), ENDCHCLR(ch), GET_REMORT_EXP(ch));
+      break;
+    case SCQ_REMORT_MULT:
+      snprintf(buf, sizeof(buf), "%sRemort Multiplier:%s %d", CHCLR(ch, 7), ENDCHCLR(ch), rv2_calc_remort_mult(ch));
+      break;
+    case SCQ_DEATH_EXP:
+      snprintf(buf, sizeof(buf), "%sDeath XP:%s %-13u", CHCLR(ch, 7), ENDCHCLR(ch), GET_DEATH_EXP(ch));
+      break;
+    case SCQ_GOLD:
+      snprintf(buf, sizeof(buf), "%sGold Carried:%s %-13d", CHCLR(ch, 7), ENDCHCLR(ch), GET_GOLD(ch));
+      break;
+    case SCQ_BANK:
+      snprintf(buf, sizeof(buf), "%sGold in Bank:%s %-13d", CHCLR(ch, 7), ENDCHCLR(ch), GET_BANK(ch));
+      break;
+    case SCQ_QUEST_TIMER:
+      if (GET_QUEST_STATUS(ch) == QUEST_NONE && !GET_QUEST_TIMER(ch)) {
+        snprintf(buf, sizeof(buf), "%sQuest Timer:%s None", CHCLR(ch, 7), ENDCHCLR(ch));
+      } else {
+        snprintf(buf, sizeof(buf), "%sQuest Timer:%s %s in %d Tick%s", CHCLR(ch, 7), ENDCHCLR(ch), GET_QUEST_STATUS(ch) == QUEST_RUNNING ? "Expires" : "Next",
+                 GET_QUEST_TIMER(ch), GET_QUEST_TIMER(ch) == 1 ? "" : "s");
+      }
+      break;
+    case SCQ_CLUB:
+      snprintf(buf, sizeof(buf), "%sMember of Club:%s ", CHCLR(ch, 7), ENDCHCLR(ch));
+
+      if (IS_SET(GET_PFLAG(ch), PLR_SANES_VOCAL_CLUB)) {
+        str_cat(buf, sizeof(buf), "Sane's Vocal Club");
+      } else if (IS_SET(GET_PFLAG(ch), PLR_LINERS_LOUNGE)) {
+        str_cat(buf, sizeof(buf), "Liner's Lounge");
+      } else if (IS_SET(GET_PFLAG(ch), PLR_LEMS_LIQOUR_ROOM)) {
+        str_cat(buf, sizeof(buf), "Lem's Liqour Room");
+      } else if (IS_SET(GET_PFLAG(ch), PLR_RANGERS_RELIQUARY)) {
+        str_cat(buf, sizeof(buf), "Ranger's Reliquary");
+      } else {
+        str_cat(buf, sizeof(buf), "None");
+      }
+      break;
+    case SCQ_CLAN:
+      snprintf(buf, sizeof(buf), "%sClan/Guild:%s %s", CHCLR(ch, 7), ENDCHCLR(ch), GET_CLAN_NAME(ch));
+      break;
+    case SCQ_PLAY_TIME:
+      snprintf(buf, sizeof(buf), "%sTime Played:%s %d Day%s, %d Hour%s", CHCLR(ch, 7), ENDCHCLR(ch), GET_PLAY_TIME(ch).day,
+               GET_PLAY_TIME(ch).day == 1 ? "" : "s", GET_PLAY_TIME(ch).hours, GET_PLAY_TIME(ch).hours == 1 ? "" : "s");
+      break;
+    case SCQ_WEIGHT_CARRIED:
+      snprintf(buf, sizeof(buf), "%sWeight Carried:%s %d of %d", CHCLR(ch, 7), ENDCHCLR(ch), IS_CARRYING_W(ch), CAN_CARRY_W(ch));
+      break;
+    case SCQ_TOGGLES:
+      snprintf(buf, sizeof(buf), "%sToggles:%s", CHCLR(ch, 7), ENDCHCLR(ch));
+
+      if (!IS_NPC(ch) && GET_PFLAG(ch)) {
+        if (IS_SET(GET_PFLAG(ch), PLR_NOKILL)) {
+          str_cat(buf, sizeof(buf), " NO_KILL");
+        }
+        if (IS_SET(GET_PFLAG(ch), PLR_NOMESSAGE)) {
+          str_cat(buf, sizeof(buf), " NO_MESSAGE");
+        }
+        if (IS_SET(GET_PFLAG(ch), PLR_NOSUMMON)) {
+          str_cat(buf, sizeof(buf), " NO_SUMMON");
+        }
+        if (IS_SET(GET_PFLAG(ch), PLR_GOSSIP)) {
+          str_cat(buf, sizeof(buf), " GOSSIP");
+        }
+        if (IS_SET(GET_PFLAG(ch), PLR_AUCTION)) {
+          str_cat(buf, sizeof(buf), " AUCTION");
+        }
+        if (IS_SET(GET_PFLAG(ch), PLR_CHAOS)) {
+          str_cat(buf, sizeof(buf), " CHAOS");
+        }
+        if (IS_SET(GET_PFLAG(ch), PLR_QUESTC)) {
+          str_cat(buf, sizeof(buf), " Q-CHANNEL");
+        }
+        if (IS_SET(GET_PFLAG(ch), PLR_QUEST)) {
+          str_cat(buf, sizeof(buf), " Q-PLAYER");
+        }
+        if (IS_SET(GET_PFLAG(ch), PLR_QUIET)) {
+          str_cat(buf, sizeof(buf), " Q-QUIET");
+        }
+        if (IS_SET(GET_PFLAG(ch), PLR_REMORT_DISABLED)) {
+          str_cat(buf, sizeof(buf), " REMORT_DISABLED");
+        }
+      } else {
+        str_cat(buf, sizeof(buf), " None");
+      }
+      break;
+    case SCQ_FLAGS:
+      if (!IS_NPC(ch) &&
+          (IS_SET(GET_PFLAG(ch), PLR_DEPUTY) || GET_COND(ch, DRUNK) > 10 || IS_SET(GET_PFLAG(ch), PLR_KILL) || IS_SET(GET_PFLAG(ch), PLR_THIEF))) {
+        if (IS_SET(GET_PFLAG(ch), PLR_DEPUTY)) {
+          snprintf(buf2, sizeof(buf2), "%sYou are a Midgaard Deputy.%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch));
+          str_cat(buf, sizeof(buf), buf2);
+        }
+
+        if (GET_COND(ch, DRUNK) > 10) {
+          snprintf(buf2, sizeof(buf2), "%sYou are intoxicated.%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch));
+          str_cat(buf, sizeof(buf), buf2);
+        }
+
+        if (IS_SET(GET_PFLAG(ch), PLR_KILL)) {
+          snprintf(buf2, sizeof(buf2), "%sYou are a killer.%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch));
+          str_cat(buf, sizeof(buf), buf2);
+        }
+
+        if (IS_SET(GET_PFLAG(ch), PLR_THIEF)) {
+          snprintf(buf2, sizeof(buf2), "%sYou are a thief.%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch));
+          str_cat(buf, sizeof(buf), buf2);
+        }
+      } else {
+        snprintf(buf, sizeof(buf), "%sFlags:%s None\n\r", CHCLR(ch, 7), ENDCHCLR(ch));
+      }
+      break;
+    case SCQ_DEATH_LIMIT:
+      if (GET_DEATH_LIMIT(ch)) {
+        snprintf(buf, sizeof(buf), "%sAfter%s %d %sdeaths you will lose stats regardless.%s", CHCLR(ch, 7), ENDCHCLR(ch), GET_DEATH_LIMIT(ch), CHCLR(ch, 7),
+                 ENDCHCLR(ch));
+      } else if (opt_text) {
+        snprintf(buf, sizeof(buf), "%sYou are not affected by a death limit.%s", CHCLR(ch, 7), ENDCHCLR(ch));
+      }
+      break;
+    case SCQ_POSITION:
+      switch (GET_POS(ch)) {
+        case POSITION_DEAD:
+          snprintf(buf, sizeof(buf), "%sYou are DEAD!%s", CHCLR(ch, 7), ENDCHCLR(ch));
+          break;
+        case POSITION_MORTALLYW:
+          snprintf(buf, sizeof(buf), "%sYou are mortally wounded! You should seek help!%s", CHCLR(ch, 7), ENDCHCLR(ch));
+          break;
+        case POSITION_INCAP:
+          snprintf(buf, sizeof(buf), "%sYou are incapacitated, slowly fading away...%s", CHCLR(ch, 7), ENDCHCLR(ch));
+          break;
+        case POSITION_STUNNED:
+          snprintf(buf, sizeof(buf), "%sYou are stunned! You can't move!%s", CHCLR(ch, 7), ENDCHCLR(ch));
+          break;
+        case POSITION_SLEEPING:
+          snprintf(buf, sizeof(buf), "%sYou are sleeping.%s", CHCLR(ch, 7), ENDCHCLR(ch));
+          break;
+        case POSITION_RESTING:
+          snprintf(buf, sizeof(buf), "%sYou are resting.%s", CHCLR(ch, 7), ENDCHCLR(ch));
+          break;
+        case POSITION_SITTING:
+          snprintf(buf, sizeof(buf), "%sYou are sitting.%s", CHCLR(ch, 7), ENDCHCLR(ch));
+          break;
+        case POSITION_FLYING:
+          snprintf(buf, sizeof(buf), "%sYou are flying.%s", CHCLR(ch, 7), ENDCHCLR(ch));
+          break;
+        case POSITION_RIDING:
+          snprintf(buf, sizeof(buf), "%sYou are riding.%s", CHCLR(ch, 7), ENDCHCLR(ch));
+          break;
+        case POSITION_SWIMMING:
+          snprintf(buf, sizeof(buf), "%sYou are swimming.%s", CHCLR(ch, 7), ENDCHCLR(ch));
+          break;
+        case POSITION_FIGHTING:
+          if (GET_OPPONENT(ch)) {
+            snprintf(buf, sizeof(buf), "%sYou are fighting %s.%s", CHCLR(ch, 7),
+                     !IS_MOB(GET_OPPONENT(ch))     ? GET_NAME(GET_OPPONENT(ch)) ? GET_NAME(GET_OPPONENT(ch)) : "(null)"
+                     : GET_SHORT(GET_OPPONENT(ch)) ? GET_SHORT(GET_OPPONENT(ch))
+                                                   : "(null)",
+                     ENDCHCLR(ch));
+          } else {
+            snprintf(buf, sizeof(buf), "%sYou are fighting thin air.%s", CHCLR(ch, 7), ENDCHCLR(ch));
+          }
+          break;
+        case POSITION_STANDING:
+          snprintf(buf, sizeof(buf), "%sYou are standing.%s", CHCLR(ch, 7), ENDCHCLR(ch));
+          break;
+        default:
+          snprintf(buf, sizeof(buf), "%sYou are floating.%s", CHCLR(ch, 7), ENDCHCLR(ch));
+          break;
+      }
+      break;
+    case SCQ_WIZINV:
+      if (IS_IMMORTAL(ch)) {
+        snprintf(buf, sizeof(buf), "%sInvisibility Level:%s %d", CHCLR(ch, 7), ENDCHCLR(ch), GET_WIZINV(ch));
+      } else {
+        snprintf(buf, sizeof(buf), "This information is for gods only.");
+      }
+      break;
+    case SCQ_EDITING_ZONE:
+      if (IS_IMMORTAL(ch)) {
+        if (ZONE_NUM_CH(ch) >= 0) {
+          snprintf(buf, sizeof(buf), "%sEditting Zone:%s %d - %s", CHCLR(ch, 7), ENDCHCLR(ch), ZONE_NUM_CH(ch),
+                   ZONE_NAME_CH(ch) ? ZONE_NAME_CH(ch) : "Undefined");
+        } else {
+          snprintf(buf, sizeof(buf), "%sEditting Zone:%s None", CHCLR(ch, 7), ENDCHCLR(ch));
+        }
+      } else {
+        snprintf(buf, sizeof(buf), "This information is for gods only.");
+      }
+      break;
+    case SCQ_THAC0:
+      snprintf(buf, sizeof(buf), "%sTHAC0:%s %+-13d", CHCLR(ch, 7), ENDCHCLR(ch), calc_thaco(ch));
+      break;
+    case SCQ_GENDER:
+      snprintf(buf, sizeof(buf), "%sGender:%s %s", CHCLR(ch, 7), ENDCHCLR(ch),
+               GET_SEX(ch) == SEX_NEUTRAL ? "Non-Binary"
+               : GET_SEX(ch) == SEX_MALE  ? "Male"
+                                          : "Female");
+      break;
+/* awaiting stat scaling updates
+    case SCQ_STR_ADD:
+      snprintf(buf, sizeof(buf), "%sStrength Add:%s %+-3d", CHCLR(ch, 7), ENDCHCLR(ch), GET_ADD(ch));
+      break;
+    case SCQ_STR_MOD:
+      snprintf(buf, sizeof(buf), "%sStrength Modifier:%s %+-2d", CHCLR(ch, 7), ENDCHCLR(ch), GET_STR_MOD(ch));
+      break;
+    case SCQ_DEX_MOD:
+      snprintf(buf, sizeof(buf), "%sDexterity Modifier:%s %+-2d", CHCLR(ch, 7), ENDCHCLR(ch), GET_DEX_MOD(ch));
+      break;
+    case SCQ_CON_MOD:
+      snprintf(buf, sizeof(buf), "%sConstitution Modifier:%s %+-2d", CHCLR(ch, 7), ENDCHCLR(ch), GET_CON_MOD(ch));
+      break;
+    case SCQ_INT_MOD:
+      snprintf(buf, sizeof(buf), "%sIntelligence Modifier:%s %+-2d", CHCLR(ch, 7), ENDCHCLR(ch), GET_INT_MOD(ch));
+      break;
+    case SCQ_WIS_MOD:
+      snprintf(buf, sizeof(buf), "%sWisdom Modifier:%s %+-2d", CHCLR(ch, 7), ENDCHCLR(ch), GET_WIS_MOD(ch));
+      break;
+*/
     default:
-      sprintf(buf, "%sYou are floating.%s",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-      break;
-    }
-    break;
-  case SCQ_WIZINV:
-    if (IS_IMMORTAL(ch))
-      sprintf(buf, "%sInvisibility Level:%s %d",
-        CHCLR(ch, 7), ENDCHCLR(ch), GET_WIZINV(ch));
-    else
-      sprintf(buf, "This information is for gods only.");
-    break;
-  case SCQ_EDITING_ZONE:
-    if (IS_IMMORTAL(ch))
-      if (ZONE_NUM_CH(ch) >= 0)
-        sprintf(buf, "%sEditting Zone:%s %d - %s",
-          CHCLR(ch, 7), ENDCHCLR(ch),
-          ZONE_NUM_CH(ch),
-          ZONE_NAME_CH(ch) ? ZONE_NAME_CH(ch) : "Undefined");
-      else
-        sprintf(buf, "%sEditting Zone:%s None",
-          CHCLR(ch, 7), ENDCHCLR(ch));
-    else
-      sprintf(buf, "This information is for gods only.");
-    break;
-  case SCQ_THAC0:
-    snprintf(buf, sizeof(buf), "%sTHAC0:%s %+-13d",
-      CHCLR(ch, 7), ENDCHCLR(ch), calc_thaco(ch));
-    break;
-  case SCQ_GENDER:
-    snprintf(buf, sizeof(buf), "%sGender:%s %-13s",
-      CHCLR(ch, 7), ENDCHCLR(ch),
-      GET_SEX(ch) == SEX_NEUTRAL ? "Non-Binary" : GET_SEX(ch) == SEX_MALE ? "Male" : "Female");
-    break;
-  default:
-    sprintf(buf, "Invalid query. See HELP \"SCORE QUERY\" for more information.");
+      snprintf(buf, sizeof(buf), "Invalid query. See HELP \"SCORE QUERY\" for more information.");
   }
 
-  if (new_line && query != SCQ_FLAGS)
-    strcat(buf, "\n\r");
+  if (new_line && query != SCQ_FLAGS) {
+    str_cat(buf, sizeof(buf), "\n\r");
+  }
 
   send_to_char(buf, ch);
 }
 
-void do_score(CHAR *ch, char *argument, int cmd)
-{
+void do_score(CHAR *ch, char *argument, int cmd) {
   char buf[MSL];
   char arg[MSL];
   int style = 0;
@@ -688,33 +602,41 @@ void do_score(CHAR *ch, char *argument, int cmd)
 
   style = GET_SCORE_STYLE(ch);
 
-  if (*buf)
-  {
-    if (is_abbrev(buf, "full") || !strcmp(buf, "0")) style = 0;
-    else if (is_abbrev(buf, "old") || !strcmp(buf, "1")) style = 1;
-    else if (is_abbrev(buf, "brief") || !strcmp(buf, "2")) style = 2;
-    else if (is_abbrev(buf, "set"))
-    {
-      if (!*arg)
-      {
+  if (*buf) {
+    if (is_abbrev(buf, "full") || !strcmp(buf, "0")) {
+      style = 0;
+    } else if (is_abbrev(buf, "old") || !strcmp(buf, "1")) {
+      style = 1;
+    } else if (is_abbrev(buf, "brief") || !strcmp(buf, "2")) {
+      style = 2;
+    } else if (is_abbrev(buf, "set")) {
+      if (!*arg) {
         send_to_char("Please specify a score style.\n\r", ch);
 
         return;
       }
 
-      sprintf(arg, "%s", skip_spaces(arg));
+      snprintf(arg, sizeof(arg), "%s", skip_spaces(arg));
 
-      if (is_number(arg)) style = atoi(arg);
-      else if (is_abbrev(arg, "full")) style = 0;
-      else if (is_abbrev(arg, "old")) style = 1;
-      else if (is_abbrev(arg, "brief")) style = 2;
-      else style = -1;
+      if (is_number(arg)) {
+        style = atoi(arg);
+      } else if (is_abbrev(arg, "full")) {
+        style = 0;
+      } else if (is_abbrev(arg, "old")) {
+        style = 1;
+      } else if (is_abbrev(arg, "brief")) {
+        style = 2;
+      } else {
+        style = -1;
+      }
 
-      if (style == 0) send_to_char("Score set to full display style.\n\r", ch);
-      else if (style == 1) send_to_char("Score set to old display style.\n\r", ch);
-      else if (style == 2) send_to_char("Score set to brief display style.\n\r", ch);
-      else
-      {
+      if (style == 0) {
+        send_to_char("Score set to full display style.\n\r", ch);
+      } else if (style == 1) {
+        send_to_char("Score set to old display style.\n\r", ch);
+      } else if (style == 2) {
+        send_to_char("Score set to brief display style.\n\r", ch);
+      } else {
         send_to_char("Invalid score style.\n\r", ch);
 
         return;
@@ -723,81 +645,152 @@ void do_score(CHAR *ch, char *argument, int cmd)
       GET_SCORE_STYLE(ch) = style;
 
       return;
-    }
-    else if (is_abbrev(buf, "query"))
-    {
-      if (!*arg)
-      {
+    } else if (is_abbrev(buf, "query")) {
+      if (!*arg) {
         send_to_char("Invalid query. See HELP \"SCORE QUERY\" for more information.\n\r", ch);
 
         return;
       }
 
-      sprintf(arg, "%s", skip_spaces(arg));
+      // snprintf(arg, sizeof(arg), "%s", skip_spaces(arg));
 
-      if (is_abbrev(arg, "name")) query = SCQ_NAME;
-      else if (is_abbrev(arg, "title")) query = SCQ_TITLE;
-      else if (is_abbrev(arg, "level")) query = SCQ_LEVEL;
-      else if (is_abbrev(arg, "class")) query = SCQ_CLASS_NAME;
-      else if (is_abbrev(arg, "subclass_name") || is_abbrev(arg, "sc_name")) query = SCQ_SC_NAME;
-      else if (is_abbrev(arg, "subclass_level") || is_abbrev(arg, "sc_level")) query = SCQ_SC_LEVEL;
-      else if (is_abbrev(arg, "rank_name")) query = SCQ_RANK_NAME;
-      else if (is_abbrev(arg, "rank_level")) query = SCQ_RANK_LEVEL;
-      else if (is_abbrev(arg, "prestige")) query = SCQ_PRESTIGE;
-      else if (is_abbrev(arg, "prestige_level")) query = SCQ_PRESTIGE_LEVEL;
-      else if (is_abbrev(arg, "maximum_hit") || is_abbrev(arg, "max_hit") || is_abbrev(arg, "hit") || is_abbrev(arg, "hp")) query = SCQ_MAX_HIT;
-      else if (is_abbrev(arg, "maximum_mana") || is_abbrev(arg, "max_mana") || is_abbrev(arg, "mana")) query = SCQ_MAX_MANA;
-      else if (is_abbrev(arg, "maximum_movement") || is_abbrev(arg, "max_movement") || is_abbrev(arg, "movement")) query = SCQ_MAX_MOVE;
-      else if (is_abbrev(arg, "natural_hit") || is_abbrev(arg, "nat_hit") || is_abbrev(arg, "natural_hp") || is_abbrev(arg, "nat_hp")) query = SCQ_NAT_HIT;
-      else if (is_abbrev(arg, "natural_mana") || is_abbrev(arg, "nat_mana")) query = SCQ_NAT_MANA;
-      else if (is_abbrev(arg, "natural_movement") || is_abbrev(arg, "nat_movement")) query = SCQ_NAT_MOVE;
-      else if (is_abbrev(arg, "gain_hit") || is_abbrev(arg, "gain_hp") || is_abbrev(arg, "hit_gain") || is_abbrev(arg, "hp_gain")) query = SCQ_HIT_GAIN;
-      else if (is_abbrev(arg, "gain_mana") || is_abbrev(arg, "mana_gain")) query = SCQ_MANA_GAIN;
-      else if (is_abbrev(arg, "gain_movement") || is_abbrev(arg, "movement_gain") || is_abbrev(arg, "move_gain")) query = SCQ_MOVE_GAIN;
-      else if (is_abbrev(arg, "current_strength") || is_abbrev(arg, "cur_strength") || is_abbrev(arg, "strength")) query = SCQ_STR;
-      else if (is_abbrev(arg, "current_dexterity") || is_abbrev(arg, "cur_dexterity") || is_abbrev(arg, "dexterity")) query = SCQ_DEX;
-      else if (is_abbrev(arg, "current_constitution") || is_abbrev(arg, "cur_constitution") || is_abbrev(arg, "constitution")) query = SCQ_CON;
-      else if (is_abbrev(arg, "current_intelligence") || is_abbrev(arg, "cur_intelligence") || is_abbrev(arg, "intelligence")) query = SCQ_INT;
-      else if (is_abbrev(arg, "current_wisdom") || is_abbrev(arg, "cur_wisdom") || is_abbrev(arg, "wisdom")) query = SCQ_WIS;
-      else if (is_abbrev(arg, "natural_strength") || is_abbrev(arg, "nat_strength")) query = SCQ_OSTR;
-      else if (is_abbrev(arg, "natural_dexterity") || is_abbrev(arg, "nat_dexterity")) query = SCQ_ODEX;
-      else if (is_abbrev(arg, "natural_constitution") || is_abbrev(arg, "nat_constitution")) query = SCQ_OCON;
-      else if (is_abbrev(arg, "natural_intelligence") || is_abbrev(arg, "nat_intelligence")) query = SCQ_OINT;
-      else if (is_abbrev(arg, "natural_wisdom") || is_abbrev(arg, "nat_wisdom")) query = SCQ_OWIS;
-      else if (is_abbrev(arg, "armor_class") || is_abbrev(arg, "ac") || is_abbrev(arg, "armor")) query = SCQ_MOD_AC;
-      else if (is_abbrev(arg, "wimpy_limit")) query = SCQ_WIMPY_LIMIT;
-      else if (is_abbrev(arg, "bleed_limit")) query = SCQ_BLEED_LIMIT;
-      else if (is_abbrev(arg, "subclass_points") || is_abbrev(arg, "subclass_pts") || is_abbrev(arg, "scp")) query = SCQ_SCP;
-      else if (is_abbrev(arg, "quest_points") || is_abbrev(arg, "qp") || is_abbrev(arg, "aqp")) query = SCQ_QP;
-      else if (is_abbrev(arg, "class_points") || is_abbrev(arg, "cpp")) query = SCQ_RANKING;
-      else if (is_abbrev(arg, "deaths")) query = SCQ_BEEN_KILLED;
-      else if (is_abbrev(arg, "age")) query = SCQ_AGE;
-      else if (is_abbrev(arg, "practices")) query = SCQ_PRAC;
-      else if (is_abbrev(arg, "average_damage") || is_abbrev(arg, "avg_damage")) query = SCQ_AVG_DAMAGE;
-      else if (is_abbrev(arg, "damroll")) query = SCQ_DAMROLL;
-      else if (is_abbrev(arg, "hitroll")) query = SCQ_HITROLL;
-      else if (is_abbrev(arg, "alignment")) query = SCQ_ALIGNMENT;
-      else if (is_abbrev(arg, "experience") || is_abbrev(arg, "xp")) query = SCQ_EXP;
-      else if (is_abbrev(arg, "exp_to_level") || is_abbrev(arg, "xp_to_level")) query = SCQ_EXP_TO_LEVEL;
-      else if (is_abbrev(arg, "remort_exp") || is_abbrev(arg, "remort_xp")) query = SCQ_REMORT_EXP;
-      else if (is_abbrev(arg, "remort_multiplier")) query = SCQ_REMORT_MULT;
-      else if (is_abbrev(arg, "death_exp") || is_abbrev(arg, "death_xp")) query = SCQ_DEATH_EXP;
-      else if (is_abbrev(arg, "gold") || is_abbrev(arg, "coins") || is_abbrev(arg, "money")) query = SCQ_GOLD;
-      else if (is_abbrev(arg, "bank_gold") || is_abbrev(arg, "bank_coins") || is_abbrev(arg, "bank_money")) query = SCQ_BANK;
-      else if (is_abbrev(arg, "quest_timer")) query = SCQ_QUEST_TIMER;
-      else if (is_abbrev(arg, "club")) query = SCQ_CLUB;
-      else if (is_abbrev(arg, "clan") || is_abbrev(arg, "guild")) query = SCQ_CLAN;
-      else if (is_abbrev(arg, "time_played") || is_abbrev(arg, "played")) query = SCQ_PLAY_TIME;
-      else if (is_abbrev(arg, "weight_carried") || is_abbrev(arg, "carried_weight")) query = SCQ_WEIGHT_CARRIED;
-      else if (is_abbrev(arg, "toggles")) query = SCQ_TOGGLES;
-      else if (is_abbrev(arg, "flags")) query = SCQ_FLAGS;
-      else if (is_abbrev(arg, "death_limit")) query = SCQ_DEATH_LIMIT;
-      else if (is_abbrev(arg, "position")) query = SCQ_POSITION;
-      else if (is_abbrev(arg, "wizinv")) query = SCQ_WIZINV;
-      else if (is_abbrev(arg, "editing_zone")) query = SCQ_EDITING_ZONE;
-      else if (is_abbrev(arg, "thac0") || is_abbrev(arg, "thaco")) query = SCQ_THAC0;
-      else if (is_abbrev(arg, "gender") || is_abbrev(arg, "sex")) query = SCQ_GENDER;
-      else {
+      if (is_abbrev(arg, "name")) {
+        query = SCQ_NAME;
+      } else if (is_abbrev(arg, "title")) {
+        query = SCQ_TITLE;
+      } else if (is_abbrev(arg, "level")) {
+        query = SCQ_LEVEL;
+      } else if (is_abbrev(arg, "class")) {
+        query = SCQ_CLASS_NAME;
+      } else if (is_abbrev(arg, "subclass_name") || is_abbrev(arg, "sc_name")) {
+        query = SCQ_SC_NAME;
+      } else if (is_abbrev(arg, "subclass_level") || is_abbrev(arg, "sc_level")) {
+        query = SCQ_SC_LEVEL;
+      } else if (is_abbrev(arg, "rank_name")) {
+        query = SCQ_RANK_NAME;
+      } else if (is_abbrev(arg, "rank_level")) {
+        query = SCQ_RANK_LEVEL;
+      } else if (is_abbrev(arg, "prestige")) {
+        query = SCQ_PRESTIGE;
+      } else if (is_abbrev(arg, "prestige_level")) {
+        query = SCQ_PRESTIGE_LEVEL;
+      } else if (is_abbrev(arg, "maximum_hit") || is_abbrev(arg, "max_hit") || is_abbrev(arg, "hit") || is_abbrev(arg, "hp")) {
+        query = SCQ_MAX_HIT;
+      } else if (is_abbrev(arg, "maximum_mana") || is_abbrev(arg, "max_mana") || is_abbrev(arg, "mana")) {
+        query = SCQ_MAX_MANA;
+      } else if (is_abbrev(arg, "maximum_movement") || is_abbrev(arg, "max_movement") || is_abbrev(arg, "movement")) {
+        query = SCQ_MAX_MOVE;
+      } else if (is_abbrev(arg, "natural_hit") || is_abbrev(arg, "nat_hit") || is_abbrev(arg, "natural_hp") || is_abbrev(arg, "nat_hp")) {
+        query = SCQ_NAT_HIT;
+      } else if (is_abbrev(arg, "natural_mana") || is_abbrev(arg, "nat_mana")) {
+        query = SCQ_NAT_MANA;
+      } else if (is_abbrev(arg, "natural_movement") || is_abbrev(arg, "nat_movement")) {
+        query = SCQ_NAT_MOVE;
+      } else if (is_abbrev(arg, "gain_hit") || is_abbrev(arg, "gain_hp") || is_abbrev(arg, "hit_gain") || is_abbrev(arg, "hp_gain")) {
+        query = SCQ_HIT_GAIN;
+      } else if (is_abbrev(arg, "gain_mana") || is_abbrev(arg, "mana_gain")) {
+        query = SCQ_MANA_GAIN;
+      } else if (is_abbrev(arg, "gain_movement") || is_abbrev(arg, "movement_gain") || is_abbrev(arg, "move_gain")) {
+        query = SCQ_MOVE_GAIN;
+      } else if (is_abbrev(arg, "current_strength") || is_abbrev(arg, "cur_strength") || is_abbrev(arg, "strength")) {
+        query = SCQ_STR;
+      } else if (is_abbrev(arg, "current_dexterity") || is_abbrev(arg, "cur_dexterity") || is_abbrev(arg, "dexterity")) {
+        query = SCQ_DEX;
+      } else if (is_abbrev(arg, "current_constitution") || is_abbrev(arg, "cur_constitution") || is_abbrev(arg, "constitution")) {
+        query = SCQ_CON;
+      } else if (is_abbrev(arg, "current_intelligence") || is_abbrev(arg, "cur_intelligence") || is_abbrev(arg, "intelligence")) {
+        query = SCQ_INT;
+      } else if (is_abbrev(arg, "current_wisdom") || is_abbrev(arg, "cur_wisdom") || is_abbrev(arg, "wisdom")) {
+        query = SCQ_WIS;
+      } else if (is_abbrev(arg, "natural_strength") || is_abbrev(arg, "nat_strength")) {
+        query = SCQ_OSTR;
+      } else if (is_abbrev(arg, "natural_dexterity") || is_abbrev(arg, "nat_dexterity")) {
+        query = SCQ_ODEX;
+      } else if (is_abbrev(arg, "natural_constitution") || is_abbrev(arg, "nat_constitution")) {
+        query = SCQ_OCON;
+      } else if (is_abbrev(arg, "natural_intelligence") || is_abbrev(arg, "nat_intelligence")) {
+        query = SCQ_OINT;
+      } else if (is_abbrev(arg, "natural_wisdom") || is_abbrev(arg, "nat_wisdom")) {
+        query = SCQ_OWIS;
+      } else if (is_abbrev(arg, "armor_class") || is_abbrev(arg, "ac") || is_abbrev(arg, "armor")) {
+        query = SCQ_MOD_AC;
+      } else if (is_abbrev(arg, "wimpy_limit")) {
+        query = SCQ_WIMPY_LIMIT;
+      } else if (is_abbrev(arg, "bleed_limit")) {
+        query = SCQ_BLEED_LIMIT;
+      } else if (is_abbrev(arg, "subclass_points") || is_abbrev(arg, "subclass_pts") || is_abbrev(arg, "scp")) {
+        query = SCQ_SCP;
+      } else if (is_abbrev(arg, "quest_points") || is_abbrev(arg, "qp") || is_abbrev(arg, "aqp")) {
+        query = SCQ_QP;
+      } else if (is_abbrev(arg, "class_points") || is_abbrev(arg, "cpp")) {
+        query = SCQ_RANKING;
+      } else if (is_abbrev(arg, "deaths")) {
+        query = SCQ_BEEN_KILLED;
+      } else if (is_abbrev(arg, "age")) {
+        query = SCQ_AGE;
+      } else if (is_abbrev(arg, "practices")) {
+        query = SCQ_PRAC;
+      } else if (is_abbrev(arg, "average_damage") || is_abbrev(arg, "avg_damage")) {
+        query = SCQ_AVG_DAMAGE;
+      } else if (is_abbrev(arg, "damroll")) {
+        query = SCQ_DAMROLL;
+      } else if (is_abbrev(arg, "hitroll")) {
+        query = SCQ_HITROLL;
+      } else if (is_abbrev(arg, "alignment")) {
+        query = SCQ_ALIGNMENT;
+      } else if (is_abbrev(arg, "experience") || is_abbrev(arg, "xp")) {
+        query = SCQ_EXP;
+      } else if (is_abbrev(arg, "exp_to_level") || is_abbrev(arg, "xp_to_level")) {
+        query = SCQ_EXP_TO_LEVEL;
+      } else if (is_abbrev(arg, "remort_exp") || is_abbrev(arg, "remort_xp")) {
+        query = SCQ_REMORT_EXP;
+      } else if (is_abbrev(arg, "remort_multiplier")) {
+        query = SCQ_REMORT_MULT;
+      } else if (is_abbrev(arg, "death_exp") || is_abbrev(arg, "death_xp")) {
+        query = SCQ_DEATH_EXP;
+      } else if (is_abbrev(arg, "gold") || is_abbrev(arg, "coins") || is_abbrev(arg, "money")) {
+        query = SCQ_GOLD;
+      } else if (is_abbrev(arg, "bank_gold") || is_abbrev(arg, "bank_coins") || is_abbrev(arg, "bank_money")) {
+        query = SCQ_BANK;
+      } else if (is_abbrev(arg, "quest_timer")) {
+        query = SCQ_QUEST_TIMER;
+      } else if (is_abbrev(arg, "club")) {
+        query = SCQ_CLUB;
+      } else if (is_abbrev(arg, "clan") || is_abbrev(arg, "guild")) {
+        query = SCQ_CLAN;
+      } else if (is_abbrev(arg, "time_played") || is_abbrev(arg, "played")) {
+        query = SCQ_PLAY_TIME;
+      } else if (is_abbrev(arg, "weight_carried") || is_abbrev(arg, "carried_weight")) {
+        query = SCQ_WEIGHT_CARRIED;
+      } else if (is_abbrev(arg, "toggles")) {
+        query = SCQ_TOGGLES;
+      } else if (is_abbrev(arg, "flags")) {
+        query = SCQ_FLAGS;
+      } else if (is_abbrev(arg, "death_limit")) {
+        query = SCQ_DEATH_LIMIT;
+      } else if (is_abbrev(arg, "position")) {
+        query = SCQ_POSITION;
+      } else if (is_abbrev(arg, "wizinv")) {
+        query = SCQ_WIZINV;
+      } else if (is_abbrev(arg, "editing_zone")) {
+        query = SCQ_EDITING_ZONE;
+      } else if (is_abbrev(arg, "thac0") || is_abbrev(arg, "thaco")) {
+        query = SCQ_THAC0;
+      } else if (is_abbrev(arg, "gender") || is_abbrev(arg, "sex")) {
+        query = SCQ_GENDER;
+      } else if (is_abbrev(arg, "strength_add") || is_abbrev(arg, "str_add")) {
+        query = SCQ_STR_ADD;
+      } else if (is_abbrev(arg, "strength_modifier") || is_abbrev(arg, "str_mod")) {
+        query = SCQ_STR_MOD;
+      } else if (is_abbrev(arg, "dexterity_modifier") || is_abbrev(arg, "dex_mod")) {
+        query = SCQ_DEX_MOD;
+      } else if (is_abbrev(arg, "constitution_modifier") || is_abbrev(arg, "con_mod")) {
+        query = SCQ_CON_MOD;
+      } else if (is_abbrev(arg, "intelligence_modifier") || is_abbrev(arg, "int_mod")) {
+        query = SCQ_INT_MOD;
+      } else if (is_abbrev(arg, "wisdom_modifier") || is_abbrev(arg, "wis_mod")) {
+        query = SCQ_WIS_MOD;
+      } else {
         send_to_char("Invalid query. See HELP \"SCORE QUERY\" for more information.\n\r", ch);
 
         return;
@@ -809,460 +802,383 @@ void do_score(CHAR *ch, char *argument, int cmd)
     }
   }
 
-  if (style == 0)
-  {
-    printf_to_char(ch, "%s%s",
-      CHCLR(ch, 7),
-      !IS_NPC(ch) ? GET_NAME(ch) ? GET_NAME(ch) : "(null)" : GET_SHORT(ch) ? GET_SHORT(ch) : "(null)");
-    if (!IS_NPC(ch))
-      printf_to_char(ch, " %s",
-        GET_TITLE(ch) ? GET_TITLE(ch) : "(no title)");
+  if (style == 0) {
+    printf_to_char(ch, "%s%s", CHCLR(ch, 7), !IS_NPC(ch) ? GET_NAME(ch) ? GET_NAME(ch) : "(null)" : GET_SHORT(ch) ? GET_SHORT(ch) : "(null)");
+    if (!IS_NPC(ch)) {
+      printf_to_char(ch, " %s", GET_TITLE(ch) ? GET_TITLE(ch) : "(no title)");
+    }
     printf_to_char(ch, "%s\n\r\n\r", ENDCHCLR(ch));
-    printf_to_char(ch, "%sLevel:    [%s%3d%s]%s %s\n\r",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_LEVEL(ch), CHCLR(ch, 7), ENDCHCLR(ch),
-      ((!IS_NPC(ch) && GET_CLASS(ch) > CLASS_NONE &&GET_CLASS(ch) <= CLASS_LAST) ||
-        (IS_NPC(ch) && GET_CLASS(ch) >= CLASS_OTHER && GET_CLASS(ch) <= CLASS_MOB_LAST)) ?
-      GET_CLASS_NAME(ch) : "Undefined");
-    if (GET_SC(ch) > SC_NONE && GET_SC(ch) <= SC_LAST)
-      printf_to_char(ch, "%sSubclass: [%s%3d%s]%s %s\n\r",
-        CHCLR(ch, 7), ENDCHCLR(ch), GET_SC_LEVEL(ch),
-        CHCLR(ch, 7), ENDCHCLR(ch), GET_SC_NAME(ch) ? GET_SC_NAME(ch) : "None");
-    if (get_rank(ch))
-      printf_to_char(ch, "%sRank:     [%s%3d%s]%s %s\n\r",
-        CHCLR(ch, 7), ENDCHCLR(ch), get_rank(ch),
-        CHCLR(ch, 7), ENDCHCLR(ch), get_rank_name(ch));
-    if (!IS_NPC(ch) && GET_PRESTIGE(ch))
-      printf_to_char(ch, "%sPrestige: [%s%3d%s]%s\n\r",
-        CHCLR(ch, 7), ENDCHCLR(ch), GET_PRESTIGE(ch),
-        CHCLR(ch, 7), ENDCHCLR(ch));
+    printf_to_char(ch, "%sLevel:    [%s%3d%s]%s %s\n\r", CHCLR(ch, 7), ENDCHCLR(ch), GET_LEVEL(ch), CHCLR(ch, 7), ENDCHCLR(ch),
+                   ((!IS_NPC(ch) && GET_CLASS(ch) > CLASS_NONE && GET_CLASS(ch) <= CLASS_LAST) ||
+                    (IS_NPC(ch) && GET_CLASS(ch) >= CLASS_OTHER && GET_CLASS(ch) <= CLASS_MOB_LAST))
+                       ? GET_CLASS_NAME(ch)
+                       : "Undefined");
+    if (GET_SC(ch) > SC_NONE && GET_SC(ch) <= SC_LAST) {
+      printf_to_char(ch, "%sSubclass: [%s%3d%s]%s %s\n\r", CHCLR(ch, 7), ENDCHCLR(ch), GET_SC_LEVEL(ch), CHCLR(ch, 7), ENDCHCLR(ch),
+                     GET_SC_NAME(ch) ? GET_SC_NAME(ch) : "None");
+    }
+    if (get_rank(ch)) {
+      printf_to_char(ch, "%sRank:     [%s%3d%s]%s %s\n\r", CHCLR(ch, 7), ENDCHCLR(ch), get_rank(ch), CHCLR(ch, 7), ENDCHCLR(ch), get_rank_name(ch));
+    }
+    if (!IS_NPC(ch) && GET_PRESTIGE(ch)) {
+      printf_to_char(ch, "%sPrestige: [%s%3d%s]%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch), GET_PRESTIGE(ch), CHCLR(ch, 7), ENDCHCLR(ch));
+    }
     send_to_char("\n\r", ch);
 
-    printf_to_char(ch, "%sMaximum HP: [%s%5d%s]   Mana: [%s%5d%s]   Move: [%s%5d%s]%s\n\r",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_MAX_HIT(ch),
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_MAX_MANA(ch),
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_MAX_MOVE(ch),
-      CHCLR(ch, 7), ENDCHCLR(ch));
-    printf_to_char(ch, "%sNatural HP: [%s%5d%s]   Mana: [%s%5d%s]   Move: [%s%5d%s]%s\n\r",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_NAT_HIT(ch),
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_NAT_MANA(ch),
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_NAT_MOVE(ch),
-      CHCLR(ch, 7), ENDCHCLR(ch));
-    printf_to_char(ch, "%sGain +- HP:  %s%+5d%s    Mana:  %s%+5d%s    Move:  %s%+5d\n\r",
-      CHCLR(ch, 7), ENDCHCLR(ch), hit_gain(ch),
-      CHCLR(ch, 7), ENDCHCLR(ch), mana_gain(ch),
-      CHCLR(ch, 7), ENDCHCLR(ch), move_gain(ch));
+    printf_to_char(ch, "%sMaximum HP: [%s%5d%s]   Mana: [%s%5d%s]   Move: [%s%5d%s]%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch), GET_MAX_HIT(ch), CHCLR(ch, 7),
+                   ENDCHCLR(ch), GET_MAX_MANA(ch), CHCLR(ch, 7), ENDCHCLR(ch), GET_MAX_MOVE(ch), CHCLR(ch, 7), ENDCHCLR(ch));
+    printf_to_char(ch, "%sNatural HP: [%s%5d%s]   Mana: [%s%5d%s]   Move: [%s%5d%s]%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch), GET_NAT_HIT(ch), CHCLR(ch, 7),
+                   ENDCHCLR(ch), GET_NAT_MANA(ch), CHCLR(ch, 7), ENDCHCLR(ch), GET_NAT_MOVE(ch), CHCLR(ch, 7), ENDCHCLR(ch));
+    printf_to_char(ch, "%sGain +- HP:  %s%+5d%s    Mana:  %s%+5d%s    Move:  %s%+5d\n\r", CHCLR(ch, 7), ENDCHCLR(ch), hit_gain(ch), CHCLR(ch, 7), ENDCHCLR(ch),
+                   mana_gain(ch), CHCLR(ch, 7), ENDCHCLR(ch), move_gain(ch));
     send_to_char("\n\r", ch);
 
-    printf_to_char(ch, "     %sNatural  Current%s       ",
-      CHCLR(ch, 7), ENDCHCLR(ch));
-    printf_to_char(ch, "%sAverage Damage:%s ",
-      CHCLR(ch, 7), ENDCHCLR(ch));
-    if ((GET_CLASS(ch) == CLASS_NINJA) || (IS_MORTAL(ch) && check_subclass(ch, SC_MERCENARY, 5)))
-      printf_to_char(ch, "%d / %d\n\r",
-        calc_hit_damage(ch, NULL, GET_WEAPON(ch), 0, RND_AVG),
-        calc_hit_damage(ch, NULL, GET_WEAPON2(ch), 0, RND_AVG));
-    else
-      printf_to_char(ch, "%d\n\r",
-        calc_hit_damage(ch, NULL, GET_WEAPON(ch), 0, RND_AVG));
-    printf_to_char(ch, "%sSTR:%s ",
-      CHCLR(ch, 7), ENDCHCLR(ch));
-    if (GET_LEVEL(ch) < 6)
+    printf_to_char(ch, "     %sNatural  Current%s       ", CHCLR(ch, 7), ENDCHCLR(ch));
+    printf_to_char(ch, "%sAverage Damage:%s ", CHCLR(ch, 7), ENDCHCLR(ch));
+    if ((GET_CLASS(ch) == CLASS_NINJA) || (IS_MORTAL(ch) && check_subclass(ch, SC_MERCENARY, 5))) {
+      printf_to_char(ch, "%d / %d\n\r", calc_hit_damage(ch, NULL, GET_WEAPON(ch), 0, RND_AVG), calc_hit_damage(ch, NULL, GET_WEAPON2(ch), 0, RND_AVG));
+    } else {
+      printf_to_char(ch, "%d\n\r", calc_hit_damage(ch, NULL, GET_WEAPON(ch), 0, RND_AVG));
+    }
+    printf_to_char(ch, "%sSTR:%s ", CHCLR(ch, 7), ENDCHCLR(ch));
+    if (GET_LEVEL(ch) < 6) {
       send_to_char("--       --            ", ch);
-    else
-    {
-      printf_to_char(ch, "%-2d",
-        GET_OSTR(ch));
-      if (GET_OSTR(ch) == 18)
-        printf_to_char(ch, "/%-3d   ",
-          GET_OADD(ch));
-      else
+    } else {
+      printf_to_char(ch, "%-2d", GET_OSTR(ch));
+      if (GET_OSTR(ch) == 18) {
+        printf_to_char(ch, "/%-3d   ", GET_OADD(ch));
+      } else {
         send_to_char("       ", ch);
-      printf_to_char(ch, "%-2d",
-        GET_STR(ch));
-      if (GET_STR(ch) == 18)
-        printf_to_char(ch, "/%-3d        ",
-          GET_ADD(ch));
-      else
+      }
+      printf_to_char(ch, "%-2d", GET_STR(ch));
+      if (GET_STR(ch) == 18) {
+        printf_to_char(ch, "/%-3d        ", GET_ADD(ch));
+      } else {
         send_to_char("            ", ch);
+      }
     }
-    printf_to_char(ch, "       %sDamroll:%s %+d\n\r",
-      CHCLR(ch, 7), ENDCHCLR(ch), calc_damroll(ch));
+    printf_to_char(ch, "       %sDamroll:%s %+d\n\r", CHCLR(ch, 7), ENDCHCLR(ch), calc_damroll(ch));
 
-    printf_to_char(ch, "%sDEX:%s ",
-      CHCLR(ch, 7), ENDCHCLR(ch));
-    if (GET_LEVEL(ch) < 6)
+    printf_to_char(ch, "%sDEX:%s ", CHCLR(ch, 7), ENDCHCLR(ch));
+    if (GET_LEVEL(ch) < 6) {
       send_to_char("--       --            ", ch);
-    else
-      printf_to_char(ch, "%-2d       %-2d            ",
-        GET_ODEX(ch), GET_DEX(ch));
-    printf_to_char(ch, "       %sHitroll:%s %+d\n\r",
-      CHCLR(ch, 7), ENDCHCLR(ch), calc_hitroll(ch));
+    } else {
+      printf_to_char(ch, "%-2d       %-2d            ", GET_ODEX(ch), GET_DEX(ch));
+    }
+    printf_to_char(ch, "       %sHitroll:%s %+d\n\r", CHCLR(ch, 7), ENDCHCLR(ch), calc_hitroll(ch));
 
-    printf_to_char(ch, "%sCON:%s ",
-      CHCLR(ch, 7), ENDCHCLR(ch));
-    if (GET_LEVEL(ch) < 6)
+    printf_to_char(ch, "%sCON:%s ", CHCLR(ch, 7), ENDCHCLR(ch));
+    if (GET_LEVEL(ch) < 6) {
       send_to_char("--       --            ", ch);
-    else
-      printf_to_char(ch, "%-2d       %-2d            ",
-        GET_OCON(ch), GET_CON(ch));
-    printf_to_char(ch, "     %sAlignment:%s %d ",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_ALIGNMENT(ch));
-    if (GET_ALIGNMENT(ch) >= 750)
+    } else {
+      printf_to_char(ch, "%-2d       %-2d            ", GET_OCON(ch), GET_CON(ch));
+    }
+    printf_to_char(ch, "     %sAlignment:%s %d ", CHCLR(ch, 7), ENDCHCLR(ch), GET_ALIGNMENT(ch));
+    if (GET_ALIGNMENT(ch) >= 750) {
       send_to_char("(Saintly)\n\r", ch);
-    else if (GET_ALIGNMENT(ch) >= 350)
+    } else if (GET_ALIGNMENT(ch) >= 350) {
       send_to_char("(Good)\n\r", ch);
-    else if (GET_ALIGNMENT(ch) > -350)
+    } else if (GET_ALIGNMENT(ch) > -350) {
       send_to_char("(Neutral)\n\r", ch);
-    else if (GET_ALIGNMENT(ch) > -750)
+    } else if (GET_ALIGNMENT(ch) > -750) {
       send_to_char("(Evil)\n\r", ch);
-    else
+    } else {
       send_to_char("(Prime Evil)\n\r", ch);
+    }
 
-    printf_to_char(ch, "%sINT:%s ",
-      CHCLR(ch, 7), ENDCHCLR(ch));
-    if (GET_LEVEL(ch) < 6)
+    printf_to_char(ch, "%sINT:%s ", CHCLR(ch, 7), ENDCHCLR(ch));
+    if (GET_LEVEL(ch) < 6) {
       send_to_char("--       --            ", ch);
-    else
-      printf_to_char(ch, "%-2d       %-2d            ",
-        GET_OINT(ch), GET_INT(ch));
-    printf_to_char(ch, "    %sExperience:%s %d\n\r",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_EXP(ch));
+    } else {
+      printf_to_char(ch, "%-2d       %-2d            ", GET_OINT(ch), GET_INT(ch));
+    }
+    printf_to_char(ch, "    %sExperience:%s %d\n\r", CHCLR(ch, 7), ENDCHCLR(ch), GET_EXP(ch));
 
-    printf_to_char(ch, "%sWIS:%s ",
-      CHCLR(ch, 7), ENDCHCLR(ch));
-    if (GET_LEVEL(ch) < 6)
+    printf_to_char(ch, "%sWIS:%s ", CHCLR(ch, 7), ENDCHCLR(ch));
+    if (GET_LEVEL(ch) < 6) {
       send_to_char("--       --            ", ch);
-    else
-      printf_to_char(ch, "%-2d       %-2d            ",
-        GET_OWIS(ch), GET_WIS(ch));
-    printf_to_char(ch, "   %sXP to Level:%s %d\n\r",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_LEVEL(ch) < LEVEL_MORT ? GET_EXP_TO_LEVEL(ch) : 0);
+    } else {
+      printf_to_char(ch, "%-2d       %-2d            ", GET_OWIS(ch), GET_WIS(ch));
+    }
+    printf_to_char(ch, "   %sXP to Level:%s %d\n\r", CHCLR(ch, 7), ENDCHCLR(ch), GET_LEVEL(ch) < LEVEL_MORT ? GET_EXP_TO_LEVEL(ch) : 0);
 
-    printf_to_char(ch, " %sArmor Class:%s %+-13d ",
-      CHCLR(ch, 7), ENDCHCLR(ch), calc_ac(ch));
-    printf_to_char(ch, "     %sRemort XP:%s %ld (%dx)\n\r",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_REMORT_EXP(ch), rv2_calc_remort_mult(ch));
+    printf_to_char(ch, " %sArmor Class:%s %+-13d ", CHCLR(ch, 7), ENDCHCLR(ch), calc_ac(ch));
+    printf_to_char(ch, "     %sRemort XP:%s %ld (%dx)\n\r", CHCLR(ch, 7), ENDCHCLR(ch), GET_REMORT_EXP(ch), rv2_calc_remort_mult(ch));
 
-    printf_to_char(ch, " %sWimpy Limit:%s %-13d       ",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_WIMPY(ch));
-    printf_to_char(ch, "%sDeath XP:%s %u (%dx)\n\r",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_DEATH_EXP(ch), calc_death_exp_mult(ch));
+    printf_to_char(ch, " %sWimpy Limit:%s %-13d       ", CHCLR(ch, 7), ENDCHCLR(ch), GET_WIMPY(ch));
+    printf_to_char(ch, "%sDeath XP:%s %u (%dx)\n\r", CHCLR(ch, 7), ENDCHCLR(ch), GET_DEATH_EXP(ch), calc_death_exp_mult(ch));
 
-    printf_to_char(ch, " %sBleed Limit:%s %-13d   ",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_BLEED(ch));
-    printf_to_char(ch, "%sGold Carried:%s %d\n\r",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_GOLD(ch));
+    printf_to_char(ch, " %sBleed Limit:%s %-13d   ", CHCLR(ch, 7), ENDCHCLR(ch), GET_BLEED(ch));
+    printf_to_char(ch, "%sGold Carried:%s %d\n\r", CHCLR(ch, 7), ENDCHCLR(ch), GET_GOLD(ch));
 
-    printf_to_char(ch, "%sSubclass Pts:%s %-13d   ",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_SCP(ch));
-    printf_to_char(ch, "%sGold in Bank:%s %d\n\r",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_BANK(ch));
+    printf_to_char(ch, "%sSubclass Pts:%s %-13d   ", CHCLR(ch, 7), ENDCHCLR(ch), GET_SCP(ch));
+    printf_to_char(ch, "%sGold in Bank:%s %d\n\r", CHCLR(ch, 7), ENDCHCLR(ch), GET_BANK(ch));
 
-    printf_to_char(ch, "%sQuest Points:%s %-13d    ",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_QP(ch));
-    if (GET_QUEST_STATUS(ch) == QUEST_NONE && !GET_QUEST_TIMER(ch))
-      printf_to_char(ch, "%sQuest Timer:%s None\n\r",
-        CHCLR(ch, 7), ENDCHCLR(ch));
-    else
-      printf_to_char(ch, "%sQuest Timer:%s %s in %d Tick%s\n\r",
-        CHCLR(ch, 7), ENDCHCLR(ch),
-        GET_QUEST_STATUS(ch) == QUEST_RUNNING ? "Expires" : "Next",
-        GET_QUEST_TIMER(ch), GET_QUEST_TIMER(ch) == 1 ? "" : "s");
+    printf_to_char(ch, "%sQuest Points:%s %-13d    ", CHCLR(ch, 7), ENDCHCLR(ch), GET_QP(ch));
+    if (GET_QUEST_STATUS(ch) == QUEST_NONE && !GET_QUEST_TIMER(ch)) {
+      printf_to_char(ch, "%sQuest Timer:%s None\n\r", CHCLR(ch, 7), ENDCHCLR(ch));
+    } else {
+      printf_to_char(ch, "%sQuest Timer:%s %s in %d Tick%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch), GET_QUEST_STATUS(ch) == QUEST_RUNNING ? "Expires" : "Next",
+                     GET_QUEST_TIMER(ch), GET_QUEST_TIMER(ch) == 1 ? "" : "s");
+    }
 
-    printf_to_char(ch, "%sClass Points:%s %-13d ",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_RANKING(ch));
-    printf_to_char(ch, "%sMember of Club:%s ",
-      CHCLR(ch, 7), ENDCHCLR(ch));
-    if (IS_SET(GET_PFLAG(ch), PLR_SANES_VOCAL_CLUB))
+    printf_to_char(ch, "%sClass Points:%s %-13d ", CHCLR(ch, 7), ENDCHCLR(ch), GET_RANKING(ch));
+    printf_to_char(ch, "%sMember of Club:%s ", CHCLR(ch, 7), ENDCHCLR(ch));
+    if (IS_SET(GET_PFLAG(ch), PLR_SANES_VOCAL_CLUB)) {
       send_to_char("Sane's Vocal Club\n\r", ch);
-    else if (IS_SET(GET_PFLAG(ch), PLR_LINERS_LOUNGE))
+    } else if (IS_SET(GET_PFLAG(ch), PLR_LINERS_LOUNGE)) {
       send_to_char("Liner's Lounge\n\r", ch);
-    else if (IS_SET(GET_PFLAG(ch), PLR_LEMS_LIQOUR_ROOM))
+    } else if (IS_SET(GET_PFLAG(ch), PLR_LEMS_LIQOUR_ROOM)) {
       send_to_char("Lem's Liqour Room\n\r", ch);
-    else if (IS_SET(GET_PFLAG(ch), PLR_RANGERS_RELIQUARY))
+    } else if (IS_SET(GET_PFLAG(ch), PLR_RANGERS_RELIQUARY)) {
       send_to_char("Ranger's Reliquary\n\r", ch);
-    else
+    } else {
       send_to_char("None\n\r", ch);
+    }
 
-    printf_to_char(ch, "%sTotal Deaths:%s %-13d     ",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_BEEN_KILLED(ch));
-    printf_to_char(ch, "%sClan/Guild:%s %s\n\r",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_CLAN_NAME(ch));
+    printf_to_char(ch, "%sTotal Deaths:%s %-13d     ", CHCLR(ch, 7), ENDCHCLR(ch), GET_BEEN_KILLED(ch));
+    printf_to_char(ch, "%sClan/Guild:%s %s\n\r", CHCLR(ch, 7), ENDCHCLR(ch), GET_CLAN_NAME(ch));
 
-    printf_to_char(ch, "%sAge in Years:%s %-13d    ",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_AGE(ch));
-    printf_to_char(ch, "%sTime Played:%s %d Day%s, %d Hour%s\n\r",
-      CHCLR(ch, 7), ENDCHCLR(ch),
-      GET_PLAY_TIME(ch).day, GET_PLAY_TIME(ch).day == 1 ? "" : "s",
-      GET_PLAY_TIME(ch).hours, GET_PLAY_TIME(ch).hours == 1 ? "" : "s");
+    printf_to_char(ch, "%sAge in Years:%s %-13d    ", CHCLR(ch, 7), ENDCHCLR(ch), GET_AGE(ch));
+    printf_to_char(ch, "%sTime Played:%s %d Day%s, %d Hour%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch), GET_PLAY_TIME(ch).day, GET_PLAY_TIME(ch).day == 1 ? "" : "s",
+                   GET_PLAY_TIME(ch).hours, GET_PLAY_TIME(ch).hours == 1 ? "" : "s");
 
-    printf_to_char(ch, "   %sPractices:%s %-13d ",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_PRAC(ch));
-    printf_to_char(ch, "%sWeight Carried:%s %d of %d\n\r",
-      CHCLR(ch, 7), ENDCHCLR(ch), IS_CARRYING_W(ch), CAN_CARRY_W(ch));
+    printf_to_char(ch, "   %sPractices:%s %-13d ", CHCLR(ch, 7), ENDCHCLR(ch), GET_PRAC(ch));
+    printf_to_char(ch, "%sWeight Carried:%s %d of %d\n\r", CHCLR(ch, 7), ENDCHCLR(ch), IS_CARRYING_W(ch), CAN_CARRY_W(ch));
     send_to_char("\n\r", ch);
 
-    if (!IS_NPC(ch))
-    {
-      printf_to_char(ch, "%sToggles:%s",
-        CHCLR(ch, 7), ENDCHCLR(ch));
+    if (!IS_NPC(ch)) {
+      printf_to_char(ch, "%sToggles:%s", CHCLR(ch, 7), ENDCHCLR(ch));
 
-      if (!IS_NPC(ch) && GET_PFLAG(ch))
-      {
-        if (IS_SET(GET_PFLAG(ch), PLR_NOKILL))
+      if (!IS_NPC(ch) && GET_PFLAG(ch)) {
+        if (IS_SET(GET_PFLAG(ch), PLR_NOKILL)) {
           send_to_char(" NO_KILL", ch);
-        if (IS_SET(GET_PFLAG(ch), PLR_NOMESSAGE))
+        }
+        if (IS_SET(GET_PFLAG(ch), PLR_NOMESSAGE)) {
           send_to_char(" NO_MESSAGE", ch);
-        if (IS_SET(GET_PFLAG(ch), PLR_NOSUMMON))
+        }
+        if (IS_SET(GET_PFLAG(ch), PLR_NOSUMMON)) {
           send_to_char(" NO_SUMMON", ch);
-        if (IS_SET(GET_PFLAG(ch), PLR_GOSSIP))
+        }
+        if (IS_SET(GET_PFLAG(ch), PLR_GOSSIP)) {
           send_to_char(" GOSSIP", ch);
-        if (IS_SET(GET_PFLAG(ch), PLR_AUCTION))
+        }
+        if (IS_SET(GET_PFLAG(ch), PLR_AUCTION)) {
           send_to_char(" AUCTION", ch);
-        if (IS_SET(GET_PFLAG(ch), PLR_CHAOS))
+        }
+        if (IS_SET(GET_PFLAG(ch), PLR_CHAOS)) {
           send_to_char(" CHAOS", ch);
-        if (IS_SET(GET_PFLAG(ch), PLR_QUESTC))
+        }
+        if (IS_SET(GET_PFLAG(ch), PLR_QUESTC)) {
           send_to_char(" Q-CHANNEL", ch);
-        if (IS_SET(GET_PFLAG(ch), PLR_QUEST))
+        }
+        if (IS_SET(GET_PFLAG(ch), PLR_QUEST)) {
           send_to_char(" Q-PLAYER", ch);
-        if (IS_SET(GET_PFLAG(ch), PLR_QUIET))
+        }
+        if (IS_SET(GET_PFLAG(ch), PLR_QUIET)) {
           send_to_char(" Q-QUIET", ch);
-        if (IS_SET(GET_PFLAG(ch), PLR_REMORT_DISABLED))
+        }
+        if (IS_SET(GET_PFLAG(ch), PLR_REMORT_DISABLED)) {
           send_to_char(" REMORT_DISABLED", ch);
+        }
         send_to_char("\n\r", ch);
-      }
-      else
+      } else {
         send_to_char(" None\n\r", ch);
+      }
     }
 
-    if (IS_IMMORTAL(ch))
-    {
-      printf_to_char(ch, "%sWiz Flags:%s ",
-        CHCLR(ch, 7), ENDCHCLR(ch));
+    if (IS_IMMORTAL(ch)) {
+      printf_to_char(ch, "%sWiz Flags:%s ", CHCLR(ch, 7), ENDCHCLR(ch));
 
-      //sprintbit(GET_IMM_FLAGS(ch), wiz_bits, buf);
+      // sprintbit(GET_IMM_FLAGS(ch), wiz_bits, buf);
       snprint_bits(buf, sizeof(buf), GET_IMM_FLAGS(ch), wiz_bits);
-      strcat(buf, "\n\r");
+      str_cat(buf, sizeof(buf), "\n\r");
 
       send_to_char(buf, ch);
     }
 
-    if (!IS_NPC(ch))
-    {
-      if (IS_SET(GET_PFLAG(ch), PLR_DEPUTY))
-        printf_to_char(ch, "%sYou are a Midgaard Deputy.%s\n\r",
-          CHCLR(ch, 7), ENDCHCLR(ch));
-      if (GET_COND(ch, DRUNK) > 10)
-        printf_to_char(ch, "%sYou are intoxicated.%s\n\r",
-          CHCLR(ch, 7), ENDCHCLR(ch));
-      if (IS_SET(GET_PFLAG(ch), PLR_KILL))
-        printf_to_char(ch, "%sYou are a killer.%s\n\r",
-          CHCLR(ch, 7), ENDCHCLR(ch));
-      if (IS_SET(GET_PFLAG(ch), PLR_THIEF))
-        printf_to_char(ch, "%sYou are a thief.%s\n\r",
-          CHCLR(ch, 7), ENDCHCLR(ch));
+    if (!IS_NPC(ch)) {
+      if (IS_SET(GET_PFLAG(ch), PLR_DEPUTY)) {
+        printf_to_char(ch, "%sYou are a Midgaard Deputy.%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch));
+      }
+      if (GET_COND(ch, DRUNK) > 10) {
+        printf_to_char(ch, "%sYou are intoxicated.%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch));
+      }
+      if (IS_SET(GET_PFLAG(ch), PLR_KILL)) {
+        printf_to_char(ch, "%sYou are a killer.%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch));
+      }
+      if (IS_SET(GET_PFLAG(ch), PLR_THIEF)) {
+        printf_to_char(ch, "%sYou are a thief.%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch));
+      }
 
-      if (GET_DEATH_LIMIT(ch))
-        printf_to_char(ch, "%sAfter%s %d %sdeaths you will lose stats regardless.%s\n\r",
-          CHCLR(ch, 7), ENDCHCLR(ch), GET_DEATH_LIMIT(ch), CHCLR(ch, 7), ENDCHCLR(ch));
+      if (GET_DEATH_LIMIT(ch)) {
+        printf_to_char(ch, "%sAfter%s %d %sdeaths you will lose stats regardless.%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch), GET_DEATH_LIMIT(ch), CHCLR(ch, 7),
+                       ENDCHCLR(ch));
+      }
     }
 
-    switch (GET_POS(ch))
-    {
+    switch (GET_POS(ch)) {
       case POSITION_DEAD:
-        printf_to_char(ch, "%sYou are DEAD!%s\n\r",
-          CHCLR(ch, 7), ENDCHCLR(ch));
+        printf_to_char(ch, "%sYou are DEAD!%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch));
         break;
       case POSITION_MORTALLYW:
-        printf_to_char(ch, "%sYou are mortally wounded! You should seek help!%s\n\r",
-          CHCLR(ch, 7), ENDCHCLR(ch));
+        printf_to_char(ch, "%sYou are mortally wounded! You should seek help!%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch));
         break;
       case POSITION_INCAP:
-        printf_to_char(ch, "%sYou are incapacitated, slowly fading away...%s\n\r",
-          CHCLR(ch, 7), ENDCHCLR(ch));
+        printf_to_char(ch, "%sYou are incapacitated, slowly fading away...%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch));
         break;
       case POSITION_STUNNED:
-        printf_to_char(ch, "%sYou are stunned! You can't move!%s\n\r",
-          CHCLR(ch, 7), ENDCHCLR(ch));
+        printf_to_char(ch, "%sYou are stunned! You can't move!%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch));
         break;
       case POSITION_SLEEPING:
-        printf_to_char(ch, "%sYou are sleeping.%s\n\r",
-          CHCLR(ch, 7), ENDCHCLR(ch));
+        printf_to_char(ch, "%sYou are sleeping.%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch));
         break;
       case POSITION_RESTING:
-        printf_to_char(ch, "%sYou are resting.%s\n\r",
-          CHCLR(ch, 7), ENDCHCLR(ch));
+        printf_to_char(ch, "%sYou are resting.%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch));
         break;
       case POSITION_SITTING:
-        printf_to_char(ch, "%sYou are sitting.%s\n\r",
-          CHCLR(ch, 7), ENDCHCLR(ch));
+        printf_to_char(ch, "%sYou are sitting.%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch));
         break;
       case POSITION_FLYING:
-        printf_to_char(ch, "%sYou are flying.%s\n\r",
-          CHCLR(ch, 7), ENDCHCLR(ch));
+        printf_to_char(ch, "%sYou are flying.%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch));
         break;
       case POSITION_RIDING:
-        printf_to_char(ch, "%sYou are riding.%s\n\r",
-          CHCLR(ch, 7), ENDCHCLR(ch));
+        printf_to_char(ch, "%sYou are riding.%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch));
         break;
       case POSITION_SWIMMING:
-        printf_to_char(ch, "%sYou are swimming.%s\n\r",
-          CHCLR(ch, 7), ENDCHCLR(ch));
+        printf_to_char(ch, "%sYou are swimming.%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch));
         break;
       case POSITION_FIGHTING:
-        if (GET_OPPONENT(ch))
-          printf_to_char(ch, "%sYou are fighting %s.%s\n\r",
-            CHCLR(ch, 7),
-            !IS_MOB(GET_OPPONENT(ch)) ?
-            GET_NAME(GET_OPPONENT(ch)) ? GET_NAME(GET_OPPONENT(ch)) : "(null)" :
-            GET_SHORT(GET_OPPONENT(ch)) ? GET_SHORT(GET_OPPONENT(ch)) : "(null)",
-            ENDCHCLR(ch));
-        else
-          printf_to_char(ch, "%sYou are fighting thin air.%s\n\r",
-          CHCLR(ch, 7), ENDCHCLR(ch));
+        if (GET_OPPONENT(ch)) {
+          printf_to_char(ch, "%sYou are fighting %s.%s\n\r", CHCLR(ch, 7),
+                         !IS_MOB(GET_OPPONENT(ch))     ? GET_NAME(GET_OPPONENT(ch)) ? GET_NAME(GET_OPPONENT(ch)) : "(null)"
+                         : GET_SHORT(GET_OPPONENT(ch)) ? GET_SHORT(GET_OPPONENT(ch))
+                                                       : "(null)",
+                         ENDCHCLR(ch));
+        } else {
+          printf_to_char(ch, "%sYou are fighting thin air.%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch));
+        }
         break;
       case POSITION_STANDING:
-        printf_to_char(ch, "%sYou are standing.%s\n\r",
-          CHCLR(ch, 7), ENDCHCLR(ch));
+        printf_to_char(ch, "%sYou are standing.%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch));
         break;
       default:
-        printf_to_char(ch, "%sYou are floating.%s\n\r",
-          CHCLR(ch, 7), ENDCHCLR(ch));
+        printf_to_char(ch, "%sYou are floating.%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch));
         break;
     }
 
     if (GET_PROTECTOR(ch)) {
-      printf_to_char(ch, "%sYou are being protected by %s.%s\n\r",
-          CHCLR(ch, 7),
-          GET_NAME(GET_PROTECTOR(ch)) ? GET_NAME(GET_PROTECTOR(ch)) : "(null)",
-          ENDCHCLR(ch));
+      printf_to_char(ch, "%sYou are being protected by %s.%s\n\r", CHCLR(ch, 7), GET_NAME(GET_PROTECTOR(ch)) ? GET_NAME(GET_PROTECTOR(ch)) : "(null)",
+                     ENDCHCLR(ch));
     }
 
     if (GET_PROTECTEE(ch)) {
-      printf_to_char(ch, "%sYou are protecting %s.%s\n\r",
-          CHCLR(ch, 7),
-          GET_NAME(GET_PROTECTEE(ch)) ? GET_NAME(GET_PROTECTEE(ch)) : "(null)",
-          ENDCHCLR(ch));
+      printf_to_char(ch, "%sYou are protecting %s.%s\n\r", CHCLR(ch, 7), GET_NAME(GET_PROTECTEE(ch)) ? GET_NAME(GET_PROTECTEE(ch)) : "(null)", ENDCHCLR(ch));
     }
 
-    if (IS_IMMORTAL(ch))
-    {
-      printf_to_char(ch, "\n\r%sInvisibility Level:%s %d\n\r",
-        CHCLR(ch, 7), ENDCHCLR(ch), GET_WIZINV(ch));
+    if (IS_IMMORTAL(ch)) {
+      printf_to_char(ch, "\n\r%sInvisibility Level:%s %d\n\r", CHCLR(ch, 7), ENDCHCLR(ch), GET_WIZINV(ch));
 
-      if (ZONE_NUM_CH(ch) >= 0)
-        printf_to_char(ch, "%sEditting Zone:%s %d - %s%s\n\r",
-          CHCLR(ch, 7), ENDCHCLR(ch),
-          ZONE_NUM_CH(ch),
-          ZONE_NAME_CH(ch) ? ZONE_NAME_CH(ch) : "Undefined",
-          ENDCHCLR(ch));
+      if (ZONE_NUM_CH(ch) >= 0) {
+        printf_to_char(ch, "%sEditting Zone:%s %d - %s%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch), ZONE_NUM_CH(ch), ZONE_NAME_CH(ch) ? ZONE_NAME_CH(ch) : "Undefined",
+                       ENDCHCLR(ch));
+      }
     }
-  }
-  else if (style == 1)
-  {
-    printf_to_char(ch, "This ranks you as %s %s%s (level %d).\n\r",
-      GET_NAME(ch) ? GET_NAME(ch) : "(null)",
-      GET_TITLE(ch) ? GET_TITLE(ch) : "(no title)",
-      ENDCHCLR(ch), GET_LEVEL(ch));
+  } else if (style == 1) {
+    printf_to_char(ch, "This ranks you as %s %s%s (level %d).\n\r", GET_NAME(ch) ? GET_NAME(ch) : "(null)", GET_TITLE(ch) ? GET_TITLE(ch) : "(no title)",
+                   ENDCHCLR(ch), GET_LEVEL(ch));
 
-    printf_to_char(ch, "You are %d years old.%s\n\r",
-      GET_AGE(ch), ((age(ch).month == 0) && (age(ch).day == 0)) ? " It's your birthday today." : "");
+    printf_to_char(ch, "You are %d years old.%s\n\r", GET_AGE(ch), ((age(ch).month == 0) && (age(ch).day == 0)) ? " It's your birthday today." : "");
 
-    printf_to_char(ch, "Your alignment is %d (-1000 to 1000) and your armor is %d (100 to %d).\n\r",
-      GET_ALIGNMENT(ch), calc_ac(ch), IS_NPC(ch) || affected_by_spell(ch, SKILL_DEFEND) ? -300 : -250);
+    printf_to_char(ch, "Your alignment is %d (-1000 to 1000) and your armor is %d (100 to %d).\n\r", GET_ALIGNMENT(ch), calc_ac(ch),
+                   IS_NPC(ch) || affected_by_spell(ch, SKILL_DEFEND) ? -300 : -250);
 
-    if (GET_ALIGNMENT(ch) >= 750)
+    if (GET_ALIGNMENT(ch) >= 750) {
       send_to_char("You are saintly.\n\r", ch);
-    else if (GET_ALIGNMENT(ch) >= 350)
+    } else if (GET_ALIGNMENT(ch) >= 350) {
       send_to_char("You are good.\n\r", ch);
-    else if (GET_ALIGNMENT(ch) >= 250)
+    } else if (GET_ALIGNMENT(ch) >= 250) {
       send_to_char("You are neutral, with tendencies towards good.\n\r", ch);
-    else if (GET_ALIGNMENT(ch) > -250)
+    } else if (GET_ALIGNMENT(ch) > -250) {
       send_to_char("You are neutral.\n\r", ch);
-    else if (GET_ALIGNMENT(ch) > -350)
+    } else if (GET_ALIGNMENT(ch) > -350) {
       send_to_char("You are neutral, with tendencies towards evil.\n\r", ch);
-    else if (GET_ALIGNMENT(ch) > -750)
+    } else if (GET_ALIGNMENT(ch) > -750) {
       send_to_char("You are evil.\n\r", ch);
-    else
+    } else {
       send_to_char("You are prime evil.\n\r", ch);
-
-    if (GET_LEVEL(ch) > 5)
-    {
-      if (GET_STR(ch) == 18)
-        printf_to_char(ch, "You have %d/%d STR, %d INT, %d WIS, %d DEX, %d CON\n\r",
-          GET_STR(ch), GET_ADD(ch), GET_INT(ch), GET_WIS(ch), GET_DEX(ch), GET_CON(ch));
-      else
-        printf_to_char(ch, "You have %d STR, %d INT, %d WIS, %d DEX, %d CON\n\r",
-          GET_STR(ch), GET_INT(ch), GET_WIS(ch), GET_DEX(ch), GET_CON(ch));
     }
 
-    printf_to_char(ch, "You have %d(%d) hit, %d(%d) mana and %d(%d) movement points.\n\r",
-      GET_HIT(ch), GET_MAX_HIT(ch), GET_MANA(ch), GET_MAX_MANA(ch), GET_MOVE(ch), GET_MAX_MOVE(ch));
-
-    if ((GET_CLASS(ch) == CLASS_NINJA) || (IS_MORTAL(ch) && check_subclass(ch, SC_MERCENARY, 5)))
-      printf_to_char(ch, "Your average damage is %d / %d.\n\r",
-        calc_hit_damage(ch, NULL, GET_WEAPON(ch), 0, RND_AVG),
-        calc_hit_damage(ch, NULL, GET_WEAPON2(ch), 0, RND_AVG));
-    else
-      printf_to_char(ch, "Your average damage is %d.\n\r",
-        calc_hit_damage(ch, NULL, GET_WEAPON(ch), 0, RND_AVG));
-
-    if (GET_LEVEL(ch) > 5)
-      printf_to_char(ch, "You are carrying %d weight, and the max weight without penalties is %d.\n\r",
-        IS_CARRYING_W(ch), CAN_CARRY_W(ch));
-
-    printf_to_char(ch, "You have scored %d exp, and have %d gold coins.\n\r",
-      GET_EXP(ch), GET_GOLD(ch));
-
-    printf_to_char(ch, "You have been playing for %d days and %d hours.\n\r",
-      GET_PLAY_TIME(ch).day, GET_PLAY_TIME(ch).hours);
-
-    if (GET_LEVEL(ch) < LEVEL_MORT)
-    {
-      printf_to_char(ch, "You need %d experience points to reach level %d.\n\r",
-        exp_table[GET_LEVEL(ch) + 1] - GET_EXP(ch), GET_LEVEL(ch) + 1);
+    if (GET_LEVEL(ch) > 5) {
+      if (GET_STR(ch) == 18) {
+        printf_to_char(ch, "You have %d/%d STR, %d INT, %d WIS, %d DEX, %d CON\n\r", GET_STR(ch), GET_ADD(ch), GET_INT(ch), GET_WIS(ch), GET_DEX(ch),
+                       GET_CON(ch));
+      } else {
+        printf_to_char(ch, "You have %d STR, %d INT, %d WIS, %d DEX, %d CON\n\r", GET_STR(ch), GET_INT(ch), GET_WIS(ch), GET_DEX(ch), GET_CON(ch));
+      }
     }
 
-    if (GET_REMORT_EXP(ch))
-    {
-      printf_to_char(ch, "You have %ld remort experience to re-earn at a %dx multiplier.\n\r",
-        GET_REMORT_EXP(ch), rv2_calc_remort_mult(ch));
+    printf_to_char(ch, "You have %d(%d) hit, %d(%d) mana and %d(%d) movement points.\n\r", GET_HIT(ch), GET_MAX_HIT(ch), GET_MANA(ch), GET_MAX_MANA(ch),
+                   GET_MOVE(ch), GET_MAX_MOVE(ch));
+
+    if ((GET_CLASS(ch) == CLASS_NINJA) || (IS_MORTAL(ch) && check_subclass(ch, SC_MERCENARY, 5))) {
+      printf_to_char(ch, "Your average damage is %d / %d.\n\r", calc_hit_damage(ch, NULL, GET_WEAPON(ch), 0, RND_AVG),
+                     calc_hit_damage(ch, NULL, GET_WEAPON2(ch), 0, RND_AVG));
+    } else {
+      printf_to_char(ch, "Your average damage is %d.\n\r", calc_hit_damage(ch, NULL, GET_WEAPON(ch), 0, RND_AVG));
     }
 
-    if (GET_DEATH_EXP(ch))
-    {
-      printf_to_char(ch, "You have %u death experience to re-earn at a %dx multiplier.\n\r",
-        GET_DEATH_EXP(ch), calc_death_exp_mult(ch));
+    if (GET_LEVEL(ch) > 5) {
+      printf_to_char(ch, "You are carrying %d weight, and the max weight without penalties is %d.\n\r", IS_CARRYING_W(ch), CAN_CARRY_W(ch));
+    }
+
+    printf_to_char(ch, "You have scored %d exp, and have %d gold coins.\n\r", GET_EXP(ch), GET_GOLD(ch));
+
+    printf_to_char(ch, "You have been playing for %d days and %d hours.\n\r", GET_PLAY_TIME(ch).day, GET_PLAY_TIME(ch).hours);
+
+    if (GET_LEVEL(ch) < LEVEL_MORT) {
+      printf_to_char(ch, "You need %d experience points to reach level %d.\n\r", exp_table[GET_LEVEL(ch) + 1] - GET_EXP(ch), GET_LEVEL(ch) + 1);
+    }
+
+    if (GET_REMORT_EXP(ch)) {
+      printf_to_char(ch, "You have %ld remort experience to re-earn at a %dx multiplier.\n\r", GET_REMORT_EXP(ch), rv2_calc_remort_mult(ch));
+    }
+
+    if (GET_DEATH_EXP(ch)) {
+      printf_to_char(ch, "You have %u death experience to re-earn at a %dx multiplier.\n\r", GET_DEATH_EXP(ch), calc_death_exp_mult(ch));
     }
 
     printf_to_char(ch, "You have %d class placement points.\n\r", GET_RANKING(ch));
     printf_to_char(ch, "You have %d quest points.\n\r", GET_QP(ch));
     printf_to_char(ch, "You have %d subclass points.\n\r", GET_SCP(ch));
 
-    if (GET_SC(ch) > SC_NONE && GET_SC(ch) <= SC_LAST)
-      printf_to_char(ch, "You are a level %d %s.\n\r",
-        GET_SC_LEVEL(ch), GET_SC_NAME(ch) ? GET_SC_NAME(ch) : "None");
-
-    if (!IS_NPC(ch) && GET_PRESTIGE(ch))
-      printf_to_char(ch, "You have %d prestige.\n\r",
-        GET_PRESTIGE(ch));
-
-    if (!IS_NPC(ch))
-    {
-      if (IS_SET(GET_PFLAG(ch), PLR_DEPUTY))
-        send_to_char("You are a Midgaard Deputy.\n\r", ch);
-      if (GET_COND(ch, DRUNK) > 10)
-        send_to_char("You are intoxicated.\n\r", ch);
-      if (IS_SET(GET_PFLAG(ch), PLR_KILL))
-        send_to_char("You are a killer.\n\r", ch);
-      if (IS_SET(GET_PFLAG(ch), PLR_THIEF))
-        send_to_char("You are a thief.\n\r", ch);
-      if (IS_SET(GET_PFLAG(ch), PLR_REMORT_DISABLED))
-        send_to_char("You are not earning remort experience.\n\r", ch);
+    if (GET_SC(ch) > SC_NONE && GET_SC(ch) <= SC_LAST) {
+      printf_to_char(ch, "You are a level %d %s.\n\r", GET_SC_LEVEL(ch), GET_SC_NAME(ch) ? GET_SC_NAME(ch) : "None");
     }
 
-    switch (GET_POS(ch))
-    {
+    if (!IS_NPC(ch) && GET_PRESTIGE(ch)) {
+      printf_to_char(ch, "You have %d prestige.\n\r", GET_PRESTIGE(ch));
+    }
+
+    if (!IS_NPC(ch)) {
+      if (IS_SET(GET_PFLAG(ch), PLR_DEPUTY)) {
+        send_to_char("You are a Midgaard Deputy.\n\r", ch);
+      }
+      if (GET_COND(ch, DRUNK) > 10) {
+        send_to_char("You are intoxicated.\n\r", ch);
+      }
+      if (IS_SET(GET_PFLAG(ch), PLR_KILL)) {
+        send_to_char("You are a killer.\n\r", ch);
+      }
+      if (IS_SET(GET_PFLAG(ch), PLR_THIEF)) {
+        send_to_char("You are a thief.\n\r", ch);
+      }
+      if (IS_SET(GET_PFLAG(ch), PLR_REMORT_DISABLED)) {
+        send_to_char("You are not earning remort experience.\n\r", ch);
+      }
+    }
+
+    switch (GET_POS(ch)) {
       case POSITION_DEAD:
         send_to_char("You are DEAD!\n\r", ch);
         break;
@@ -1294,13 +1210,14 @@ void do_score(CHAR *ch, char *argument, int cmd)
         send_to_char("You are swimming.\n\r", ch);
         break;
       case POSITION_FIGHTING:
-        if (GET_OPPONENT(ch))
+        if (GET_OPPONENT(ch)) {
           printf_to_char(ch, "You are fighting %s.\n\r",
-            !IS_MOB(GET_OPPONENT(ch)) ?
-            GET_NAME(GET_OPPONENT(ch)) ? GET_NAME(GET_OPPONENT(ch)) : "(null)" :
-            GET_SHORT(GET_OPPONENT(ch)) ? GET_SHORT(GET_OPPONENT(ch)) : "(null)");
-        else
+                         !IS_MOB(GET_OPPONENT(ch))     ? GET_NAME(GET_OPPONENT(ch)) ? GET_NAME(GET_OPPONENT(ch)) : "(null)"
+                         : GET_SHORT(GET_OPPONENT(ch)) ? GET_SHORT(GET_OPPONENT(ch))
+                                                       : "(null)");
+        } else {
           send_to_char("You are fighting thin air.\n\r", ch);
+        }
         break;
       case POSITION_STANDING:
         send_to_char("You are standing.\n\r", ch);
@@ -1310,147 +1227,133 @@ void do_score(CHAR *ch, char *argument, int cmd)
         break;
     }
 
-    if (!IS_NPC(ch))
-    {
-      if (GET_WIMPY(ch) > 0)
-        printf_to_char(ch, "You will flee when you only have %d hit points.\n\r",
-          GET_WIMPY(ch));
+    if (!IS_NPC(ch)) {
+      if (GET_WIMPY(ch) > 0) {
+        printf_to_char(ch, "You will flee when you only have %d hit points.\n\r", GET_WIMPY(ch));
+      }
 
-      if (GET_BLEED(ch) > 0)
-        printf_to_char(ch, "You will be warned about bleeding at %d hit points.\n\r",
-          GET_BLEED(ch));
+      if (GET_BLEED(ch) > 0) {
+        printf_to_char(ch, "You will be warned about bleeding at %d hit points.\n\r", GET_BLEED(ch));
+      }
 
-      if (GET_DEATH_LIMIT(ch) > 0)
-        printf_to_char(ch, "After %d deaths you will lose stats regardless.\n\r",
-          GET_DEATH_LIMIT(ch));
+      if (GET_DEATH_LIMIT(ch) > 0) {
+        printf_to_char(ch, "After %d deaths you will lose stats regardless.\n\r", GET_DEATH_LIMIT(ch));
+      }
 
-      if (IS_SET(GET_PFLAG(ch), PLR_SANES_VOCAL_CLUB))
+      if (IS_SET(GET_PFLAG(ch), PLR_SANES_VOCAL_CLUB)) {
         send_to_char("You are a member of Sane's Vocal Club.\n\r", ch);
-      else if (IS_SET(GET_PFLAG(ch), PLR_LINERS_LOUNGE))
+      } else if (IS_SET(GET_PFLAG(ch), PLR_LINERS_LOUNGE)) {
         send_to_char("You are a member of Liner's Lounge.\n\r", ch);
-      else if (IS_SET(GET_PFLAG(ch), PLR_LEMS_LIQOUR_ROOM))
+      } else if (IS_SET(GET_PFLAG(ch), PLR_LEMS_LIQOUR_ROOM)) {
         send_to_char("You are a member of Lem's Liqour Room.\n\r", ch);
-      else if (IS_SET(GET_PFLAG(ch), PLR_RANGERS_RELIQUARY))
+      } else if (IS_SET(GET_PFLAG(ch), PLR_RANGERS_RELIQUARY)) {
         send_to_char("You are a member of Ranger's Reliquary.\n\r", ch);
+      }
 
-      if (GET_CLAN_NUM(ch))
+      if (GET_CLAN_NUM(ch)) {
         printf_to_char(ch, "You are a member of %s.\n\r", GET_CLAN_NAME(ch));
+      }
 
-      if (GET_PFLAG(ch))
-      {
+      if (GET_PFLAG(ch)) {
         send_to_char("You are affected by : ", ch);
-        if (GET_PFLAG(ch))
-        {
-          if (IS_SET(GET_PFLAG(ch), PLR_NOKILL))
+        if (GET_PFLAG(ch)) {
+          if (IS_SET(GET_PFLAG(ch), PLR_NOKILL)) {
             send_to_char("NO_KILL ", ch);
-          if (IS_SET(GET_PFLAG(ch), PLR_NOMESSAGE))
+          }
+          if (IS_SET(GET_PFLAG(ch), PLR_NOMESSAGE)) {
             send_to_char("NO_MESSAGE ", ch);
-          if (IS_SET(GET_PFLAG(ch), PLR_NOSUMMON))
+          }
+          if (IS_SET(GET_PFLAG(ch), PLR_NOSUMMON)) {
             send_to_char("NO_SUMMON ", ch);
-          if (IS_SET(GET_PFLAG(ch), PLR_GOSSIP))
+          }
+          if (IS_SET(GET_PFLAG(ch), PLR_GOSSIP)) {
             send_to_char("GOSSIP ", ch);
-          if (IS_SET(GET_PFLAG(ch), PLR_AUCTION))
+          }
+          if (IS_SET(GET_PFLAG(ch), PLR_AUCTION)) {
             send_to_char("AUCTION ", ch);
-          if (IS_SET(GET_PFLAG(ch), PLR_CHAOS))
+          }
+          if (IS_SET(GET_PFLAG(ch), PLR_CHAOS)) {
             send_to_char("CHAOS ", ch);
-          if (IS_SET(GET_PFLAG(ch), PLR_QUESTC))
+          }
+          if (IS_SET(GET_PFLAG(ch), PLR_QUESTC)) {
             send_to_char("Q-CHANNEL ", ch);
-          if (IS_SET(GET_PFLAG(ch), PLR_QUEST))
+          }
+          if (IS_SET(GET_PFLAG(ch), PLR_QUEST)) {
             send_to_char("Q-PLAYER ", ch);
-          if (IS_SET(GET_PFLAG(ch), PLR_QUIET))
+          }
+          if (IS_SET(GET_PFLAG(ch), PLR_QUIET)) {
             send_to_char("Q-QUIET ", ch);
-          if (IS_SET(GET_PFLAG(ch), PLR_REMORT_DISABLED))
+          }
+          if (IS_SET(GET_PFLAG(ch), PLR_REMORT_DISABLED)) {
             send_to_char(" REMORT_DISABLED", ch);
+          }
           send_to_char(" \n\r", ch);
         }
       }
     }
 
-    if (IS_IMMORTAL(ch))
-    {
+    if (IS_IMMORTAL(ch)) {
       printf_to_char(ch, "Your invisibility level is %d.\n\r", GET_WIZINV(ch));
 
-      if (ZONE_NUM_CH(ch) >= 0)
-        printf_to_char(ch, "You are editting zone %d - %s.\n\r",
-          ZONE_NUM_CH(ch), ZONE_NAME_CH(ch) ? ZONE_NAME_CH(ch) : "Undefined");
+      if (ZONE_NUM_CH(ch) >= 0) {
+        printf_to_char(ch, "You are editting zone %d - %s.\n\r", ZONE_NUM_CH(ch), ZONE_NAME_CH(ch) ? ZONE_NAME_CH(ch) : "Undefined");
+      }
     }
-  }
-  else if (style == 2)
-  {
-    printf_to_char(ch, "%s%s",
-      CHCLR(ch, 7),
-      !IS_NPC(ch) ? GET_NAME(ch) ? GET_NAME(ch) : "(null)" : GET_SHORT(ch) ? GET_SHORT(ch) : "(null)");
-    if (!IS_NPC(ch))
-      printf_to_char(ch, " %s",
-        GET_TITLE(ch) ? GET_TITLE(ch) : "(no title)");
+  } else if (style == 2) {
+    printf_to_char(ch, "%s%s", CHCLR(ch, 7), !IS_NPC(ch) ? GET_NAME(ch) ? GET_NAME(ch) : "(null)" : GET_SHORT(ch) ? GET_SHORT(ch) : "(null)");
+    if (!IS_NPC(ch)) {
+      printf_to_char(ch, " %s", GET_TITLE(ch) ? GET_TITLE(ch) : "(no title)");
+    }
     printf_to_char(ch, "%s\n\r\n\r", ENDCHCLR(ch));
-    printf_to_char(ch, "%sLevel:    [%s%3d%s]%s %s\n\r",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_LEVEL(ch), CHCLR(ch, 7), ENDCHCLR(ch),
-      ((!IS_NPC(ch) && GET_CLASS(ch) > CLASS_NONE &&GET_CLASS(ch) <= CLASS_LAST) ||
-        (IS_NPC(ch) && GET_CLASS(ch) >= CLASS_OTHER && GET_CLASS(ch) <= CLASS_MOB_LAST)) ?
-      GET_CLASS_NAME(ch) : "Undefined");
-    if (GET_SC(ch) > SC_NONE && GET_SC(ch) <= SC_LAST)
-      printf_to_char(ch, "%sSubclass: [%s%3d%s]%s %s\n\r",
-        CHCLR(ch, 7), ENDCHCLR(ch), GET_SC_LEVEL(ch),
-        CHCLR(ch, 7), ENDCHCLR(ch), GET_SC_NAME(ch) ? GET_SC_NAME(ch) : "None");
-    if (get_rank(ch))
-      printf_to_char(ch, "%sRank:     [%s%3d%s]%s %s\n\r",
-        CHCLR(ch, 7), ENDCHCLR(ch), get_rank(ch),
-        CHCLR(ch, 7), ENDCHCLR(ch), get_rank_name(ch));
-    if (!IS_NPC(ch) && GET_PRESTIGE(ch))
-      printf_to_char(ch, "%sPrestige: [%s%3d%s]%s\n\r",
-        CHCLR(ch, 7), ENDCHCLR(ch), GET_PRESTIGE(ch),
-        CHCLR(ch, 7), ENDCHCLR(ch));
+    printf_to_char(ch, "%sLevel:    [%s%3d%s]%s %s\n\r", CHCLR(ch, 7), ENDCHCLR(ch), GET_LEVEL(ch), CHCLR(ch, 7), ENDCHCLR(ch),
+                   ((!IS_NPC(ch) && GET_CLASS(ch) > CLASS_NONE && GET_CLASS(ch) <= CLASS_LAST) ||
+                    (IS_NPC(ch) && GET_CLASS(ch) >= CLASS_OTHER && GET_CLASS(ch) <= CLASS_MOB_LAST))
+                       ? GET_CLASS_NAME(ch)
+                       : "Undefined");
+    if (GET_SC(ch) > SC_NONE && GET_SC(ch) <= SC_LAST) {
+      printf_to_char(ch, "%sSubclass: [%s%3d%s]%s %s\n\r", CHCLR(ch, 7), ENDCHCLR(ch), GET_SC_LEVEL(ch), CHCLR(ch, 7), ENDCHCLR(ch),
+                     GET_SC_NAME(ch) ? GET_SC_NAME(ch) : "None");
+    }
+    if (get_rank(ch)) {
+      printf_to_char(ch, "%sRank:     [%s%3d%s]%s %s\n\r", CHCLR(ch, 7), ENDCHCLR(ch), get_rank(ch), CHCLR(ch, 7), ENDCHCLR(ch), get_rank_name(ch));
+    }
+    if (!IS_NPC(ch) && GET_PRESTIGE(ch)) {
+      printf_to_char(ch, "%sPrestige: [%s%3d%s]%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch), GET_PRESTIGE(ch), CHCLR(ch, 7), ENDCHCLR(ch));
+    }
     send_to_char("\n\r", ch);
 
-    printf_to_char(ch, "%sMaximum HP: [%s%5d%s]  Mana: [%s%5d%s]  Move: [%s%5d%s]%s\n\r",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_MAX_HIT(ch),
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_MAX_MANA(ch),
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_MAX_MOVE(ch),
-      CHCLR(ch, 7), ENDCHCLR(ch));
-    printf_to_char(ch, "%sGain +- HP:  %s%+5d%s   Mana:  %s%+5d%s   Move:  %s%+5d\n\r\n\r",
-      CHCLR(ch, 7), ENDCHCLR(ch), hit_gain(ch),
-      CHCLR(ch, 7), ENDCHCLR(ch), mana_gain(ch),
-      CHCLR(ch, 7), ENDCHCLR(ch), move_gain(ch));
+    printf_to_char(ch, "%sMaximum HP: [%s%5d%s]  Mana: [%s%5d%s]  Move: [%s%5d%s]%s\n\r", CHCLR(ch, 7), ENDCHCLR(ch), GET_MAX_HIT(ch), CHCLR(ch, 7),
+                   ENDCHCLR(ch), GET_MAX_MANA(ch), CHCLR(ch, 7), ENDCHCLR(ch), GET_MAX_MOVE(ch), CHCLR(ch, 7), ENDCHCLR(ch));
+    printf_to_char(ch, "%sGain +- HP:  %s%+5d%s   Mana:  %s%+5d%s   Move:  %s%+5d\n\r\n\r", CHCLR(ch, 7), ENDCHCLR(ch), hit_gain(ch), CHCLR(ch, 7),
+                   ENDCHCLR(ch), mana_gain(ch), CHCLR(ch, 7), ENDCHCLR(ch), move_gain(ch));
 
-    printf_to_char(ch, " %sArmor Class:%s %+-13d ",
-      CHCLR(ch, 7), ENDCHCLR(ch), calc_ac(ch));
-    printf_to_char(ch, "     %sAlignment:%s %d ",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_ALIGNMENT(ch));
-    if (GET_ALIGNMENT(ch) >= 750)
+    printf_to_char(ch, " %sArmor Class:%s %+-13d ", CHCLR(ch, 7), ENDCHCLR(ch), calc_ac(ch));
+    printf_to_char(ch, "     %sAlignment:%s %d ", CHCLR(ch, 7), ENDCHCLR(ch), GET_ALIGNMENT(ch));
+    if (GET_ALIGNMENT(ch) >= 750) {
       send_to_char("(Saintly)\n\r", ch);
-    else if (GET_ALIGNMENT(ch) >= 350)
+    } else if (GET_ALIGNMENT(ch) >= 350) {
       send_to_char("(Good)\n\r", ch);
-    else if (GET_ALIGNMENT(ch) > -350)
+    } else if (GET_ALIGNMENT(ch) > -350) {
       send_to_char("(Neutral)\n\r", ch);
-    else if (GET_ALIGNMENT(ch) > -750)
+    } else if (GET_ALIGNMENT(ch) > -750) {
       send_to_char("(Evil)\n\r", ch);
-    else
+    } else {
       send_to_char("(Prime Evil)\n\r", ch);
+    }
 
-    printf_to_char(ch, "%sGold Carried:%s %-13d     ",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_GOLD(ch));
-    printf_to_char(ch, "%sExperience:%s %d\n\r",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_EXP(ch));
+    printf_to_char(ch, "%sGold Carried:%s %-13d     ", CHCLR(ch, 7), ENDCHCLR(ch), GET_GOLD(ch));
+    printf_to_char(ch, "%sExperience:%s %d\n\r", CHCLR(ch, 7), ENDCHCLR(ch), GET_EXP(ch));
 
-    printf_to_char(ch, "%sGold in Bank:%s %-13d    ",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_BANK(ch));
-    printf_to_char(ch, "%sXP to Level:%s %d\n\r",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_EXP_TO_LEVEL(ch));
+    printf_to_char(ch, "%sGold in Bank:%s %-13d    ", CHCLR(ch, 7), ENDCHCLR(ch), GET_BANK(ch));
+    printf_to_char(ch, "%sXP to Level:%s %d\n\r", CHCLR(ch, 7), ENDCHCLR(ch), GET_EXP_TO_LEVEL(ch));
 
-    printf_to_char(ch, "%sSubclass Pts:%s %-13d      ",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_SCP(ch));
-    printf_to_char(ch, "%sRemort XP:%s %ld (%dx)\n\r",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_REMORT_EXP(ch), rv2_calc_remort_mult(ch));
+    printf_to_char(ch, "%sSubclass Pts:%s %-13d      ", CHCLR(ch, 7), ENDCHCLR(ch), GET_SCP(ch));
+    printf_to_char(ch, "%sRemort XP:%s %ld (%dx)\n\r", CHCLR(ch, 7), ENDCHCLR(ch), GET_REMORT_EXP(ch), rv2_calc_remort_mult(ch));
 
-    printf_to_char(ch, "%sQuest Points:%s %-13d       ",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_QP(ch));
-    printf_to_char(ch, "%sDeath XP:%s %u (%dx)\n\r",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_DEATH_EXP(ch), calc_death_exp_mult(ch));
+    printf_to_char(ch, "%sQuest Points:%s %-13d       ", CHCLR(ch, 7), ENDCHCLR(ch), GET_QP(ch));
+    printf_to_char(ch, "%sDeath XP:%s %u (%dx)\n\r", CHCLR(ch, 7), ENDCHCLR(ch), GET_DEATH_EXP(ch), calc_death_exp_mult(ch));
 
-    printf_to_char(ch, "%sAge in Years:%s %-13d ",
-      CHCLR(ch, 7), ENDCHCLR(ch), GET_AGE(ch));
-    printf_to_char(ch, "%sWeight Carried:%s %d of %d\n\r",
-      CHCLR(ch, 7), ENDCHCLR(ch), IS_CARRYING_W(ch), CAN_CARRY_W(ch));
+    printf_to_char(ch, "%sAge in Years:%s %-13d ", CHCLR(ch, 7), ENDCHCLR(ch), GET_AGE(ch));
+    printf_to_char(ch, "%sWeight Carried:%s %d of %d\n\r", CHCLR(ch, 7), ENDCHCLR(ch), IS_CARRYING_W(ch), CAN_CARRY_W(ch));
   }
 }

--- a/src/score.h
+++ b/src/score.h
@@ -2,9 +2,7 @@
   score.h - Improved do_score() and related functions
 
   Written by Alan K. Miles for RoninMUD
-  Last Modification Date: 10/21/2012
 */
-/* Project Epee */
 
 #ifndef _SCORE_H_
 #define _SCORE_H_
@@ -73,6 +71,12 @@
 #define SCQ_PRESTIGE       59
 #define SCQ_THAC0          60
 #define SCQ_GENDER         61
+#define SCQ_STR_ADD        62
+#define SCQ_STR_MOD        63
+#define SCQ_DEX_MOD        64
+#define SCQ_CON_MOD        65
+#define SCQ_INT_MOD        66
+#define SCQ_WIS_MOD        67
 
 void score_query(CHAR *ch, int query, bool opt_text, bool new_line);
 void do_score(CHAR *ch, char *argument, int cmd);

--- a/src/spec.desert.c
+++ b/src/spec.desert.c
@@ -143,7 +143,7 @@ int cavalier(CHAR *cavalier,CHAR *ch, int cmd, char *arg) {
        act("$n streams blue holy light from his fingers at $N!",0,cavalier,0,vict,TO_NOTVICT);
        act("$n consumes you in a torrent of holy light!",0,cavalier,0,vict,TO_VICT);
        act("You pray to your Gods and stream blue holy light toward $N.",0,cavalier,0,vict,TO_CHAR);
-       GET_HIT(vict)=-10;
+       GET_HIT(vict)=200;
        break;
       case 4:
        if(!(vict=get_random_victim_fighting(cavalier))) return FALSE;
@@ -153,7 +153,7 @@ int cavalier(CHAR *cavalier,CHAR *ch, int cmd, char *arg) {
        act("As $n prays, a flash of light eclipses $N.",0,cavalier,0,vict,TO_NOTVICT);
        act("$n mumbles a prayer, and you are eclipsed within a flash of light.",0,cavalier,0,vict,TO_VICT);
        act("You pray to your Gods and a flash of light eclipses $N.",0,cavalier,0,vict,TO_CHAR);
-       GET_MANA(vict)=number(0,100);
+       GET_MANA(vict) = GET_MANA(vict) / 2;
        break;
       case 5:
        act("$n emits a keening whistle to summon his trusty steed!",1,cavalier,0,0,TO_ROOM);

--- a/src/spec.dionysus.c
+++ b/src/spec.dionysus.c
@@ -156,7 +156,7 @@ int basilisk(CHAR *mob, CHAR *ch, int cmd, char *arg)
 		act("$n swings $s head around and makes eye contact with you, turning you to stone.",0,mob,0,vict,TO_VICT);
 		act("$n swings $s head around and makes eye contact with $N, turning $M to stone.",0,mob,0,vict,TO_NOTVICT);
 		act("You swing your head around and make eye contact with $N, turning $M to stone.",0,mob,0,vict,TO_CHAR);
-		spell_petrify(GET_LEVEL(mob), mob, vict, 0);		
+		spell_petrify(GET_LEVEL(mob), mob, vict, TRUE);		
 	}
 	return FALSE;
 }

--- a/src/spec.elf.c
+++ b/src/spec.elf.c
@@ -33,6 +33,7 @@
 #include "cmd.h"
 #include "spec_assign.h"
 #include "mob.spells.h"
+#include "enchant.h"
 
 /* Zones */
 
@@ -96,6 +97,7 @@
 void stop_fighting (CHAR *ch);
 void hit (CHAR *ch, CHAR *vict, int type);
 char *one_argument(char *arg, char *buf);
+extern int greasy_palms(ENCH *ench, CHAR *ench_ch, CHAR *ch, int cmd, char *arg);
 
 bool
 is_caster (CHAR *ch) {
@@ -455,6 +457,7 @@ Demon (CHAR *demon, CHAR *ch, int cmd, char *arg) {
   int dir;
   char buf[MAX_INPUT_LENGTH];
   bool move_ch = FALSE;
+  ENCH *tmp_enchantment;
 
   if (cmd)
     return FALSE;
@@ -464,36 +467,27 @@ Demon (CHAR *demon, CHAR *ch, int cmd, char *arg) {
 
   vict = GET_OPPONENT(demon);
 
-  if (EQ(vict,WIELD) && number(0,1)) {
-    ob = unequip_char (vict, WIELD);
-    act("With a swift snap of $s tail, $n sends\n\r$p flying from $N's hands.",
-	FALSE,demon,ob,vict,TO_NOTVICT);
-    act("With a swift snap of $s tail, $n sends\n\r$p flying from your hands.",
-	FALSE,demon,ob,vict,TO_VICT);
-    act("With a swift snap of your tail, you send\n$p flying from $N's hands.",
-	FALSE,demon,ob,vict,TO_CHAR);
-
-    dir = number (1,3);
-
-    if (CAN_GO (demon, dir))
-      move_ch = TRUE;
-
-    if (move_ch) {
-      act ("$p flies out of the Vault's door...",FALSE,demon,ob,0,TO_ROOM);
-      obj_to_room(ob,EXIT(demon,dir)->to_room_r);
-      /* Added disarm log, Solmyr - 2009 */
-      sprintf(buf, "WIZINFO: %s disarms %s's %s and puts it in room %d", GET_NAME(demon), GET_NAME(vict), OBJ_SHORT(ob), world[EXIT(demon,dir)->to_room_r].number);
+  if ((ob = EQ(vict,WIELD))) {
+    if (chance(50)) {
+      act("With a swift snap of $s tail, $n knocks $p from $N's hands.",FALSE,demon,ob,vict,TO_NOTVICT);
+      act("With a swift snap of $s tail, $n knocks $p from your hands.",FALSE,demon,ob,vict,TO_VICT);
+      act("With a swift snap of your tail, you knock $p from $N's hands.",FALSE,demon,ob,vict,TO_CHAR);
+    }
+    else { //greasy tongue slime
+      act("With a disgusting squelch, $n's greasy tongue wrenches $p from $N's grasp.",FALSE,demon,ob,vict,TO_NOTVICT);
+      act("With a disgusting squelch, $n's greasy tongue wrenches $p from your grasp.",FALSE,demon,ob,vict,TO_VICT);
+      act("With a satisfying squelch, your regal tongue wrenches $p from $N's grasp.",FALSE,demon,ob,vict,TO_CHAR);
+      CREATE(tmp_enchantment, ENCH, 1);
+      tmp_enchantment->name     = str_dup("Greasy Palms");
+      tmp_enchantment->duration = 1;
+      tmp_enchantment->func     = greasy_palms;
+      enchantment_to_char(vict, tmp_enchantment, FALSE);
+      sprintf(buf,"Hell Log Ench: [ %s just contracted Greasy Palms at %d ]",GET_NAME(vict),world[CHAR_REAL_ROOM(vict)].number);
       log_s(buf);
-      ob->log = TRUE;
-    } else
-    	{
-      	obj_to_room (ob, CHAR_REAL_ROOM(demon));
-      	/* Added disarm log, Solmyr - 2009 */
-      	sprintf(buf, "WIZINFO: %s disarms %s's %s in room %d", GET_NAME(demon), GET_NAME(vict), OBJ_SHORT(ob), world[CHAR_REAL_ROOM(demon)].number);
-      	log_s(buf);
-      	ob->log = TRUE;
-      }
-
+    }
+    //disarm to inventory
+    unequip_char(vict, WIELD);
+    obj_to_char(ob, vict);
     return FALSE;
   }
 
@@ -504,31 +498,23 @@ Demon (CHAR *demon, CHAR *ch, int cmd, char *arg) {
     if (CAN_GO (demon, dir))
       move_ch = TRUE;
 
-    if (move_ch) {
-      act("With a swift snap of $s tail,\n\r$n sends $N flying...",
-	  FALSE,demon,0,vict,TO_NOTVICT);
-      act("With a swift snap of $s tail,\n\r$n sends you flying...EEAOOWW!!",
-	  FALSE,demon,0,vict,TO_VICT);
-      act("With a swift snap of your tail,\n\ryou send $N flying...",
-	  FALSE,demon,0,vict,TO_CHAR);
+    if (move_ch && (10*GET_HIT(demon)/GET_MAX_HIT(demon) > 6)) {
+      act("With a swift snap of $s tail, $n sends $N flying...",FALSE,demon,0,vict,TO_NOTVICT);
+      act("With a swift snap of $s tail, $n sends you flying...EEAOOWW!!",FALSE,demon,0,vict,TO_VICT);
+      act("With a swift snap of your tail, you send $N flying...",FALSE,demon,0,vict,TO_CHAR);
 
       char_from_room(vict);
       char_to_room(vict,EXIT(demon,dir)->to_room_r);
 
-      act("$n arrives flying high, and crashes on the floor.",
-	  FALSE,vict,0,0,TO_ROOM);
+      act("$n arrives flying high, and crashes on the floor.",FALSE,vict,0,0,TO_ROOM);
       WAIT_STATE(vict,3*PULSE_VIOLENCE);
       return FALSE;
     } else {
-      act("With a swift snap of $s tail,\n$n sends $N flying to the wall.",
-	  FALSE,demon,0,vict,TO_NOTVICT);
-      act("With a swift snap of $s tail,\n$n sends you flying to the wall.",
-	  FALSE,demon,0,vict,TO_VICT);
-      act("With a swift snap of your tail,\nyou send $N flying to the wall.",
-	  FALSE,demon,0,vict,TO_CHAR);
+      act("With a swift snap of $s tail, $n sends $N flying to the wall.",FALSE,demon,0,vict,TO_NOTVICT);
+      act("With a swift snap of $s tail, $n sends you flying to the wall.",FALSE,demon,0,vict,TO_VICT);
+      act("With a swift snap of your tail, you send $N flying to the wall.",FALSE,demon,0,vict,TO_CHAR);
 
-      if (GET_OPPONENT (vict))
-	stop_fighting (vict);
+      if (GET_OPPONENT (vict)) stop_fighting (vict);
 
       GET_POS (vict) = POSITION_STUNNED;
       WAIT_STATE (vict, 3*PULSE_VIOLENCE);
@@ -801,19 +787,15 @@ int
 Beastmaster (CHAR *bm, CHAR *ch, int cmd, char *arg) {
   CHAR *vict;
   OBJ *o;
-  char buf[MAX_INPUT_LENGTH];
 
   if (cmd) {
     switch (cmd) {
     case CMD_CIRCLE:
-      act("$n quickly dodges your vain attempt and takes a wild swing at you.",
-	  FALSE,bm,0,ch,TO_VICT);
-      act("You quickly dodge $N's vain attempt and take a wild swing at $M.",
-	  FALSE,bm,0,ch,TO_CHAR);
-      act("$n quickly dodges $N's vain attempt and takes a wild swing at $M.",
-	  FALSE,bm,0,ch,TO_NOTVICT);
+      act("$n quickly dodges your vain attempt and takes a wild swing at you.",FALSE,bm,0,ch,TO_VICT);
+      act("You quickly dodge $N's vain attempt and take a wild swing at $M.",FALSE,bm,0,ch,TO_CHAR);
+      act("$n quickly dodges $N's vain attempt and takes a wild swing at $M.",FALSE,bm,0,ch,TO_NOTVICT);
       hit (bm,ch,TYPE_HIT);
-      return TRUE ;
+      return TRUE;
 
     case CMD_PUNCH:
     case CMD_PUMMEL:
@@ -821,24 +803,18 @@ Beastmaster (CHAR *bm, CHAR *ch, int cmd, char *arg) {
     case CMD_BASH:
     case CMD_HIT:
     case CMD_KILL:
-      act("$n notices your attempt and takes a wild swing at you.",
-	  FALSE,bm,0,ch,TO_VICT);
-      act("You notice $N's attempt and take a wild swing at $M.",
-	  FALSE,bm,0,ch,TO_CHAR);
-      act("$n notice $N's attempt and takes a wild swing at $M.",
-	  FALSE,bm,0,ch,TO_NOTVICT);
+      act("$n notices your attempt and takes a wild swing at you.",FALSE,bm,0,ch,TO_VICT);
+      act("You notice $N's attempt and take a wild swing at $M.",FALSE,bm,0,ch,TO_CHAR);
+      act("$n notice $N's attempt and takes a wild swing at $M.",FALSE,bm,0,ch,TO_NOTVICT);
       hit (bm,ch,TYPE_HIT);
       return FALSE;
 
     case CMD_CAST:
     case CMD_SONG:
     case CMD_RECITE:
-      act("$n notices your attempt to use magic and swings right at you.",
-	  FALSE,bm,0,ch,TO_VICT);
-      act("You notice $N's attempt to use magic and swing right at $M.",
-	  FALSE,bm,0,ch,TO_CHAR);
-      act("$n notice $N's attempt and swings right at $M.",
-	  FALSE,bm,0,ch,TO_NOTVICT);
+      act("$n notices your attempt to use magic and swings right at you.",FALSE,bm,0,ch,TO_VICT);
+      act("You notice $N's attempt to use magic and swing right at $M.",FALSE,bm,0,ch,TO_CHAR);
+      act("$n notice $N's attempt and swings right at $M.",FALSE,bm,0,ch,TO_NOTVICT);
       damage (bm, ch, number (100,200), TYPE_HIT,DAM_PHYSICAL);
       return FALSE;
 
@@ -850,7 +826,6 @@ Beastmaster (CHAR *bm, CHAR *ch, int cmd, char *arg) {
   if (!(vict = GET_OPPONENT(bm))) return FALSE;
 
   switch (number(0,2)) {
-
   case 0:
     act("$n takes a hefty swing with at your legs.",FALSE,bm,0,vict,TO_VICT);
     act("$n takes a hefty swing at $N's legs.",FALSE,bm,0,vict,TO_NOTVICT);
@@ -867,19 +842,12 @@ Beastmaster (CHAR *bm, CHAR *ch, int cmd, char *arg) {
     break;
 
   case 2:
-    if (EQ(vict,WIELD)) {
-      o = EQ(vict, WIELD);
-      act("Your weapon goes flying, as $n hits it lightly.",
-	  FALSE,bm,o,vict,TO_VICT);
-      act("$N's weapon goes flying, as $n hits it lightly.",
-	  FALSE,bm,o,vict,TO_NOTVICT);
-      act("$N's weapon goes flying, as you hit it lightly.",
-	  FALSE,bm,o,vict,TO_CHAR);
+    if ((o = EQ(vict,WIELD))) {
+      act("Your weapon is knocked from your grasp as $n hits it deftly.",FALSE,bm,o,vict,TO_VICT);
+      act("$N's weapon is knocked from $S grasp as $n hits it deftly.",FALSE,bm,o,vict,TO_NOTVICT);
+      act("$N's weapon is knocked from $S grasp as you hit it deftly.",FALSE,bm,o,vict,TO_CHAR);
       unequip_char (vict, WIELD);
-      obj_to_room (o, CHAR_REAL_ROOM(vict));
-	    sprintf(buf, "WIZINFO: %s disarms %s's %s at %d", GET_NAME(bm), GET_NAME(vict), OBJ_SHORT(o), world[CHAR_REAL_ROOM(bm)].number);
-	    log_s(buf);
-	    o->log = TRUE;
+      obj_to_char (o, vict);
     }
     break;
   }

--- a/src/spec.invasion.c
+++ b/src/spec.invasion.c
@@ -191,7 +191,7 @@ int basilisk_spec(CHAR *mob, CHAR *ch, int cmd, char *arg) {
       act("$n gazes deep into $N's eyes and turns $M to stone!", FALSE, mob, 0, vict, TO_NOTVICT);
       act("$n gazes deep into your eyes and turns you to stone!", FALSE, mob, 0, vict, TO_VICT);
 
-      spell_petrify(GET_LEVEL(mob), mob, vict, 0);
+      spell_petrify(GET_LEVEL(mob), mob, vict, TRUE);
     }
 
     return FALSE;

--- a/src/spec.moria.c
+++ b/src/spec.moria.c
@@ -409,11 +409,11 @@ int uber_stone_dragon(CHAR *uber, CHAR *ch, int cmd, char *arg) {
     REMOVE_BIT( uber->specials.act, ACT_AGGNO );
     sprintf( buf, "%s roars angrily, and a thundering crack of shattered stone echoes off the walls.\n\r", GET_SHORT(uber) );
     send_to_room(buf, CHAR_REAL_ROOM(uber) );
-    statues = MIN ( count_mortals_room(uber, TRUE), number(1,4) );
+    statues = MIN ( count_mortals_room(uber, TRUE), number(0,2) );
     for( i = 0; i < statues; i++ ) {
       vict = get_random_victim(uber);
       if( vict ) {
-         spell_petrify( GET_LEVEL(uber), uber, vict, 0);
+         spell_petrify( GET_LEVEL(uber), uber, vict, FALSE);
       }
     }
   }
@@ -422,11 +422,11 @@ int uber_stone_dragon(CHAR *uber, CHAR *ch, int cmd, char *arg) {
     SET_BIT( uber->specials.act, ACT_SHIELD );
     sprintf( buf, "%s roars loudly, causing the stone of the cavern and the earth to shiver and quake at its power.\n\r", GET_SHORT(uber) );
     send_to_room(buf, CHAR_REAL_ROOM(uber) );
-    statues = MIN ( count_mortals_room(uber, TRUE), number(2,5) );
+    statues = MIN ( count_mortals_room(uber, TRUE), number(1,3) );
     for( i = 0; i < statues; i++ ) {
       vict = get_random_victim(uber);
       if( vict ) {
-        spell_petrify( GET_LEVEL(uber), uber, vict, 0);
+        spell_petrify( GET_LEVEL(uber), uber, vict, FALSE);
       }
     }
   }

--- a/src/spec.pagoda.c
+++ b/src/spec.pagoda.c
@@ -92,7 +92,7 @@ int p_tyrant(CHAR *mob, CHAR *ch, int cmd, char *arg) {
 /* Petrify any in room except tank */
   if(!number(0,4)) {
     if((vict=get_random_victim(mob))){
-      if (vict!=mob->specials.fighting) spell_petrify (LEVEL_IMM,mob,vict,0);
+      if (vict!=mob->specials.fighting) spell_petrify (LEVEL_IMM,mob,vict,FALSE);
       return FALSE;
     }
   }

--- a/src/spec.topknot.c
+++ b/src/spec.topknot.c
@@ -396,75 +396,29 @@ tk_assist_random (CHAR *ch)
   return 0;
 }
 
-void
-tk_baron_drain (CHAR *ch, CHAR *v)
+void tk_baron_drain (CHAR *ch, CHAR *vict)
 {
   int chance = number (1,100);
 
-  if (chance < 60)
-    {
-      if(v->points.max_hit>0) {
-        v->points.max_hit = MAX (v->points.max_hit - number (1,4), 0);
-        GET_HIT (v) = MIN (GET_MAX_HIT (v), GET_HIT (v));
-      }
+  if (chance < 50) {
+    if(GET_MAX_MOVE(vict) > 0) {
+      GET_MAX_MOVE_POINTS(vict) = MAX (GET_MAX_MOVE_POINTS(vict) - number (1,30), 0);
+      GET_MOVE(vict) = MIN (GET_MAX_MOVE(vict), GET_MOVE(vict));
     }
-  else if (chance < 65)
-    {
-      if(v->points.max_mana>0) {
-        v->points.max_mana = MAX (v->points.max_mana - number (1,4), 0);
-        GET_MANA (v) = MIN (GET_MAX_MANA (v), GET_MANA (v));
-      }
+  }
+  else if (chance < 75) {
+    if(GET_MAX_MANA(vict) > 0) {
+      GET_MAX_MANA_POINTS(vict) = MAX (GET_MAX_MANA_POINTS(vict) - number (1,4), 0);
+      GET_MANA(vict) = MIN (GET_MAX_MANA(vict), GET_MANA(vict));
     }
-  else if (chance < 70)
-    {
-      if(v->points.max_move>0) {
-        v->points.max_move = MAX (v->points.max_move - number (1,10), 0);
-        GET_MOVE (v) = MIN (GET_MAX_MOVE (v), GET_MOVE (v));
-      }
+  }
+  else {
+    if(GET_MAX_HIT(vict) > 0) {
+      GET_MAX_HIT_POINTS(vict) = MAX (GET_MAX_HIT_POINTS(vict) - number (1,6), 0);
+      GET_HIT(vict) = MIN (GET_MAX_HIT(vict), GET_HIT(vict));
     }
-  else if (chance < 79)
-    {
-      if (v->abilities.str == 18 && v->abilities.str_add > 0)
-	{
-	  v->abilities.str_add = MAX (0,v->abilities.str_add - number (1,2));
-	  v->tmpabilities.str_add = v->abilities.str_add;
-	}
-      else
-	{
-	  v->abilities.str = MAX (3,v->abilities.str - 1);
-	  v->tmpabilities.str = v->abilities.str;
-	}
-    }
-  else if (chance < 80)
-    {
-      v->abilities.intel = MAX (3,v->abilities.intel - 1);
-      v->tmpabilities.intel = v->abilities.intel;
-    }
-  else if (chance < 85)
-    {
-      v->abilities.wis = MAX (3,v->abilities.wis - 1);
-      v->tmpabilities.wis = v->abilities.wis;
-    }
-  else if (chance < 90)
-    {
-      v->abilities.dex = MAX (3,v->abilities.dex - 1);
-      v->tmpabilities.dex = v->abilities.dex;
-    }
-  else if (chance < 95)
-    {
-      v->abilities.con = MAX (3,v->abilities.con - 1);
-      v->tmpabilities.con = v->abilities.con;
-    }
-  else if (chance < 99)
-    v->points.exp = MAX (0, v->points.exp * number (1,50) / 100);
-  else
-    {
-      GET_LEVEL (v) = GET_LEVEL (v) - 1;
-      GET_EXP (v) = 0;
-      v->points.max_hit -= ((v->points.max_hit)-10)/(GET_LEVEL (v));
-      v->points.max_mana -= ((v->points.max_mana)/GET_LEVEL (v));
-    }
-  affect_total (v);
+  }
+  affect_total (vict);
 }
 
 OBJ *tk_get_loot_inv(CHAR *k, CHAR *ch) {

--- a/src/spells.c
+++ b/src/spells.c
@@ -1955,24 +1955,30 @@ void cast_disenchant(ubyte level, CHAR *ch, char *arg, int type, CHAR *victim, O
 }
 
 void cast_petrify(ubyte level, CHAR *ch, char *arg, int type, CHAR *victim, OBJ *obj) {
-  if (!IS_NPC(ch) && (GET_LEVEL(ch) < LEVEL_WIZ)) {
+  if (type != SPELL_TYPE_POTION && !IS_NPC(ch) && (GET_LEVEL(ch) < LEVEL_WIZ)) {
     send_to_char("Your level isn't high enough to cast this spell.\n\r", ch);
-
     return;
   }
 
   switch (type) {
     case SPELL_TYPE_POTION:
-      victim = ch;
+      act("Your throat tightens and soon so does your whole body as you're turned to stone.", FALSE, ch, 0, ch, TO_CHAR);
+      act("You stare in horror as $N turns to solid stone from the inside out.", FALSE, ch, 0, ch, TO_NOTVICT);
+      spell_petrify(level, ch, ch, TRUE);
+      break;
     case SPELL_TYPE_SPELL:
     case SPELL_TYPE_WAND:
     case SPELL_TYPE_SCROLL:
-      spell_petrify(level, ch, victim, 0);
+      spell_petrify(level, ch, victim, FALSE);
       break;
+/* removed support for STAFF type because aoe_spell() doesn't work with struct change to
+   spell_petrify, changed 4th arg from 'struct obj_data *obj' to 'bool skip_msg' - if
+   staff function needed later, can do a manual loop through the room
 
     case SPELL_TYPE_STAFF:
-      aoe_spell(ch, spell_petrify, level, 0);
+      aoe_spell(ch, spell_petrify, level, FALSE);
       break;
+*/
   }
 }
 

--- a/src/spells.h
+++ b/src/spells.h
@@ -871,7 +871,7 @@ void spell_disenchant(ubyte level, struct char_data *ch,
   struct char_data *victim, struct obj_data *obj);
 
 void spell_petrify(ubyte level, struct char_data *ch,
-  struct char_data *victim, struct obj_data *obj);
+  struct char_data *victim, bool skip_msg);
 
 void spell_protection_from_good(ubyte level, struct char_data *ch,
   struct char_data *victim, struct obj_data *obj);

--- a/src/subclass.c
+++ b/src/subclass.c
@@ -789,6 +789,7 @@ const int no_teleport_zones[] = {
   260, // Questy Vader III
   261, // Questy Nosferatu
   262, // Quest by Hemp
+  263, // Christmas Village
   275, // Clan Halls
   278, // ISAHall
   285, // Enchanted Forest


### PR DESCRIPTION
Batch of fixes/improvements: spec balance issues, AQ timer inconsistencies, kick/score bugs, and a new petrify potion.
Unrelated QoL changes bundled together since they were all small enough to ship in one pass.

* Adjust Baron bite spec
* Adjust BM disarm
* Adjust Rep Demon disarm
* Adjust Cavalier instakill and mana burn specs
* Fix AQ timer inconsistencies (rent, quit, death, hotboot)
* Adjust spell_petrify() function, include support for petrify potion
* Add a potion of petrify on Big Stone
* Adjust Uber Stone Dragon phase shift stonings
* Fix kick without a target: potatoFive's work
* Fix score query: Night's work
* Re-enable Baron item in AQ orders
* Remove SPHERE from Xalwithr
* Remove Christmas Village from Rashgugh zone list